### PR TITLE
Extract motion sensor data and steam data via udp protocol

### DIFF
--- a/CRC.h
+++ b/CRC.h
@@ -1,0 +1,1699 @@
+/**
+    @file CRC.h
+    @author Daniel Bahr
+    @version 0.2.0.6
+    @copyright
+    @parblock
+        CRC++
+        Copyright (c) 2016, Daniel Bahr
+        All rights reserved.
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+
+        * Redistributions of source code must retain the above copyright notice, this
+          list of conditions and the following disclaimer.
+
+        * Redistributions in binary form must reproduce the above copyright notice,
+          this list of conditions and the following disclaimer in the documentation
+          and/or other materials provided with the distribution.
+
+        * Neither the name of CRC++ nor the names of its
+          contributors may be used to endorse or promote products derived from
+          this software without specific prior written permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+        AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+        FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+        DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+        CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+        OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+        OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    @endparblock
+*/
+
+/*
+    CRC++ can be configured by setting various #defines before #including this header file:
+
+        #define crcpp_uint8                             - Specifies the type used to store CRCs that have a width of 8 bits or less.
+                                                          This type is not used in CRC calculations. Defaults to ::std::uint8_t.
+        #define crcpp_uint16                            - Specifies the type used to store CRCs that have a width between 9 and 16 bits (inclusive).
+                                                          This type is not used in CRC calculations. Defaults to ::std::uint16_t.
+        #define crcpp_uint32                            - Specifies the type used to store CRCs that have a width between 17 and 32 bits (inclusive).
+                                                          This type is not used in CRC calculations. Defaults to ::std::uint32_t.
+        #define crcpp_uint64                            - Specifies the type used to store CRCs that have a width between 33 and 64 bits (inclusive).
+                                                          This type is not used in CRC calculations. Defaults to ::std::uint64_t.
+        #define crcpp_size                              - This type is used for loop iteration and function signatures only. Defaults to ::std::size_t.
+        #define CRCPP_USE_NAMESPACE                     - Define to place all CRC++ code within the ::CRCPP namespace.
+        #define CRCPP_BRANCHLESS                        - Define to enable a branchless CRC implementation. The branchless implementation uses a single integer
+                                                          multiplication in the bit-by-bit calculation instead of a small conditional. The branchless implementation
+                                                          may be faster on processor architectures which support single-instruction integer multiplication.
+        #define CRCPP_USE_CPP11                         - Define to enables C++11 features (move semantics, constexpr, static_assert, etc.).
+        #define CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS  - Define to include definitions for little-used CRCs. 
+*/
+
+#ifndef CRCPP_CRC_H_
+#define CRCPP_CRC_H_
+
+#include <climits>  // Includes CHAR_BIT
+#ifdef CRCPP_USE_CPP11
+#include <cstddef>  // Includes ::std::size_t
+#include <cstdint>  // Includes ::std::uint8_t, ::std::uint16_t, ::std::uint32_t, ::std::uint64_t
+#else
+#include <stddef.h> // Includes size_t
+#include <stdint.h> // Includes uint8_t, uint16_t, uint32_t, uint64_t
+#endif
+#include <limits>   // Includes ::std::numeric_limits
+#include <utility>  // Includes ::std::move
+
+#ifndef crcpp_uint8
+#   ifdef CRCPP_USE_CPP11
+        /// @brief Unsigned 8-bit integer definition, used primarily for parameter definitions.
+#       define crcpp_uint8 ::std::uint8_t
+#   else
+        /// @brief Unsigned 8-bit integer definition, used primarily for parameter definitions.
+#       define crcpp_uint8 uint8_t
+#   endif
+#endif
+
+#ifndef crcpp_uint16
+#   ifdef CRCPP_USE_CPP11
+        /// @brief Unsigned 16-bit integer definition, used primarily for parameter definitions.
+#       define crcpp_uint16 ::std::uint16_t
+#   else
+        /// @brief Unsigned 16-bit integer definition, used primarily for parameter definitions.
+#       define crcpp_uint16 uint16_t
+#   endif
+#endif
+
+#ifndef crcpp_uint32
+#   ifdef CRCPP_USE_CPP11
+        /// @brief Unsigned 32-bit integer definition, used primarily for parameter definitions.
+#       define crcpp_uint32 ::std::uint32_t
+#   else
+        /// @brief Unsigned 32-bit integer definition, used primarily for parameter definitions.
+#       define crcpp_uint32 uint32_t
+#   endif
+#endif
+
+#ifndef crcpp_uint64
+#   ifdef CRCPP_USE_CPP11
+        /// @brief Unsigned 64-bit integer definition, used primarily for parameter definitions.
+#       define crcpp_uint64 ::std::uint64_t
+#   else
+        /// @brief Unsigned 64-bit integer definition, used primarily for parameter definitions.
+#       define crcpp_uint64 uint64_t
+#   endif
+#endif
+
+#ifndef crcpp_size
+#   ifdef CRCPP_USE_CPP11
+        /// @brief Unsigned size definition, used for specifying data sizes.
+#       define crcpp_size ::std::size_t
+#   else
+        /// @brief Unsigned size definition, used for specifying data sizes.
+#       define crcpp_size size_t
+#   endif
+#endif
+
+#ifdef CRCPP_USE_CPP11
+    /// @brief Compile-time expression definition.
+#   define crcpp_constexpr constexpr
+#else
+    /// @brief Compile-time expression definition.
+#   define crcpp_constexpr const
+#endif
+
+#ifdef CRCPP_USE_NAMESPACE
+namespace CRCPP
+{
+#endif
+
+/**
+    @brief Static class for computing CRCs.
+    @note This class supports computation of full and multi-part CRCs, using a bit-by-bit algorithm or a
+        byte-by-byte lookup table. The CRCs are calculated using as many optimizations as is reasonable.
+        If compiling with C++11, the constexpr keyword is used liberally so that many calculations are
+        performed at compile-time instead of at runtime.
+*/
+class CRC
+{
+public:
+    // Forward declaration
+    template <typename CRCType, crcpp_uint16 CRCWidth>
+    struct Table;
+
+    /**
+        @brief CRC parameters.
+    */
+    template <typename CRCType, crcpp_uint16 CRCWidth>
+    struct Parameters
+    {
+        CRCType polynomial;   ///< CRC polynomial
+        CRCType initialValue; ///< Initial CRC value
+        CRCType finalXOR;     ///< Value to XOR with the final CRC
+        bool reflectInput;    ///< true to reflect all input bytes
+        bool reflectOutput;   ///< true to reflect the output CRC (reflection occurs before the final XOR)
+
+        Table<CRCType, CRCWidth> MakeTable() const;
+    };
+
+    /**
+        @brief CRC lookup table. After construction, the CRC parameters are fixed.
+        @note A CRC table can be used for multiple CRC calculations.
+    */
+    template <typename CRCType, crcpp_uint16 CRCWidth>
+    struct Table
+    {
+        // Constructors are intentionally NOT marked explicit.
+        Table(const Parameters<CRCType, CRCWidth> & parameters);
+
+#ifdef CRCPP_USE_CPP11
+        Table(Parameters<CRCType, CRCWidth> && parameters);
+#endif
+
+        const Parameters<CRCType, CRCWidth> & GetParameters() const;
+
+        const CRCType * GetTable() const;
+
+        CRCType operator[](unsigned char index) const;
+
+    private:
+        void InitTable();
+
+        Parameters<CRCType, CRCWidth> parameters; ///< CRC parameters used to construct the table
+        CRCType table[1 << CHAR_BIT];             ///< CRC lookup table
+    };
+
+    // The number of bits in CRCType must be at least as large as CRCWidth.
+    // CRCType must be an unsigned integer type or a custom type with operator overloads.
+    template <typename CRCType, crcpp_uint16 CRCWidth>
+    static CRCType Calculate(const void * data, crcpp_size size, const Parameters<CRCType, CRCWidth> & parameters);
+
+    template <typename CRCType, crcpp_uint16 CRCWidth>
+    static CRCType Calculate(const void * data, crcpp_size size, const Parameters<CRCType, CRCWidth> & parameters, CRCType crc);
+
+    template <typename CRCType, crcpp_uint16 CRCWidth>
+    static CRCType Calculate(const void * data, crcpp_size size, const Table<CRCType, CRCWidth> & lookupTable);
+
+    template <typename CRCType, crcpp_uint16 CRCWidth>
+    static CRCType Calculate(const void * data, crcpp_size size, const Table<CRCType, CRCWidth> & lookupTable, CRCType crc);
+
+    // Common CRCs up to 64 bits.
+    // Note: Check values are the computed CRCs when given an ASCII input of "123456789" (without null terminator)
+#ifdef CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+    static const Parameters< crcpp_uint8,  4> & CRC_4_ITU();
+    static const Parameters< crcpp_uint8,  5> & CRC_5_EPC();
+    static const Parameters< crcpp_uint8,  5> & CRC_5_ITU();
+    static const Parameters< crcpp_uint8,  5> & CRC_5_USB();
+    static const Parameters< crcpp_uint8,  6> & CRC_6_CDMA2000A();
+    static const Parameters< crcpp_uint8,  6> & CRC_6_CDMA2000B();
+    static const Parameters< crcpp_uint8,  6> & CRC_6_ITU();
+    static const Parameters< crcpp_uint8,  7> & CRC_7();
+#endif
+    static const Parameters< crcpp_uint8,  8> & CRC_8();
+#ifdef CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+    static const Parameters< crcpp_uint8,  8> & CRC_8_EBU();
+    static const Parameters< crcpp_uint8,  8> & CRC_8_MAXIM();
+    static const Parameters< crcpp_uint8,  8> & CRC_8_WCDMA();
+    static const Parameters<crcpp_uint16, 10> & CRC_10();
+    static const Parameters<crcpp_uint16, 10> & CRC_10_CDMA2000();
+    static const Parameters<crcpp_uint16, 11> & CRC_11();
+    static const Parameters<crcpp_uint16, 12> & CRC_12_CDMA2000();
+    static const Parameters<crcpp_uint16, 12> & CRC_12_DECT();
+    static const Parameters<crcpp_uint16, 12> & CRC_12_UMTS();
+    static const Parameters<crcpp_uint16, 13> & CRC_13_BBC();
+    static const Parameters<crcpp_uint16, 15> & CRC_15();
+    static const Parameters<crcpp_uint16, 15> & CRC_15_MPT1327();
+#endif
+    static const Parameters<crcpp_uint16, 16> & CRC_16_ARC();
+    static const Parameters<crcpp_uint16, 16> & CRC_16_BUYPASS();
+    static const Parameters<crcpp_uint16, 16> & CRC_16_CCITTFALSE();
+#ifdef CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+    static const Parameters<crcpp_uint16, 16> & CRC_16_CDMA2000();
+    static const Parameters<crcpp_uint16, 16> & CRC_16_DECTR();
+    static const Parameters<crcpp_uint16, 16> & CRC_16_DECTX();
+    static const Parameters<crcpp_uint16, 16> & CRC_16_DNP();
+#endif
+    static const Parameters<crcpp_uint16, 16> & CRC_16_GENIBUS();
+    static const Parameters<crcpp_uint16, 16> & CRC_16_KERMIT();
+#ifdef CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+    static const Parameters<crcpp_uint16, 16> & CRC_16_MAXIM();
+    static const Parameters<crcpp_uint16, 16> & CRC_16_MODBUS();
+    static const Parameters<crcpp_uint16, 16> & CRC_16_T10DIF();
+    static const Parameters<crcpp_uint16, 16> & CRC_16_USB();
+#endif
+    static const Parameters<crcpp_uint16, 16> & CRC_16_X25();
+    static const Parameters<crcpp_uint16, 16> & CRC_16_XMODEM();
+#ifdef CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+    static const Parameters<crcpp_uint32, 17> & CRC_17_CAN();
+    static const Parameters<crcpp_uint32, 21> & CRC_21_CAN();
+    static const Parameters<crcpp_uint32, 24> & CRC_24();
+    static const Parameters<crcpp_uint32, 24> & CRC_24_FLEXRAYA();
+    static const Parameters<crcpp_uint32, 24> & CRC_24_FLEXRAYB();
+    static const Parameters<crcpp_uint32, 30> & CRC_30();
+#endif
+    static const Parameters<crcpp_uint32, 32> & CRC_32();
+    static const Parameters<crcpp_uint32, 32> & CRC_32_BZIP2();
+#ifdef CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+    static const Parameters<crcpp_uint32, 32> & CRC_32_C();
+#endif
+    static const Parameters<crcpp_uint32, 32> & CRC_32_MPEG2();
+    static const Parameters<crcpp_uint32, 32> & CRC_32_POSIX();
+#ifdef CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+    static const Parameters<crcpp_uint32, 32> & CRC_32_Q();
+    static const Parameters<crcpp_uint64, 40> & CRC_40_GSM();
+    static const Parameters<crcpp_uint64, 64> & CRC_64();
+#endif
+
+#ifdef CRCPP_USE_CPP11
+    CRC() = delete;
+    CRC(const CRC & other) = delete;
+    CRC & operator=(const CRC & other) = delete;
+    CRC(CRC && other) = delete;
+    CRC & operator=(CRC && other) = delete;
+#endif
+
+private:
+#ifndef CRCPP_USE_CPP11
+    CRC();
+    CRC(const CRC & other);
+    CRC & operator=(const CRC & other);
+#endif
+
+    template <typename IntegerType>
+    static IntegerType Reflect(IntegerType value, crcpp_uint16 numBits);
+
+    template <typename CRCType, crcpp_uint16 CRCWidth>
+    static CRCType Finalize(CRCType remainder, CRCType finalXOR, bool reflectOutput);
+
+    template <typename CRCType, crcpp_uint16 CRCWidth>
+    static CRCType UndoFinalize(CRCType remainder, CRCType finalXOR, bool reflectOutput);
+
+    template <typename CRCType, crcpp_uint16 CRCWidth>
+    static CRCType CalculateRemainder(const void * data, crcpp_size size, const Parameters<CRCType, CRCWidth> & parameters, CRCType remainder);
+
+    template <typename CRCType, crcpp_uint16 CRCWidth>
+    static CRCType CalculateRemainder(const void * data, crcpp_size size, const Table<CRCType, CRCWidth> & lookupTable, CRCType remainder);
+
+    template <typename IntegerType>
+    static crcpp_constexpr IntegerType BoundedConstexprValue(IntegerType x);
+};
+
+/**
+    @brief Returns a CRC lookup table construct using these CRC parameters.
+    @note This function primarily exists to allow use of the auto keyword instead of instantiating
+        a table directly, since template parameters are not inferred in constructors.
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+    @return CRC lookup table
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline CRC::Table<CRCType, CRCWidth> CRC::Parameters<CRCType, CRCWidth>::MakeTable() const
+{
+    // This should take advantage of RVO and optimize out the copy.
+    return CRC::Table<CRCType, CRCWidth>(*this);
+}
+
+/**
+    @brief Constructs a CRC table from a set of CRC parameters
+    @param[in] parameters CRC parameters
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline CRC::Table<CRCType, CRCWidth>::Table(const Parameters<CRCType, CRCWidth> & parameters) :
+    parameters(parameters)
+{
+    InitTable();
+}
+
+#ifdef CRCPP_USE_CPP11
+/**
+    @brief Constructs a CRC table from a set of CRC parameters
+    @param[in] parameters CRC parameters
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline CRC::Table<CRCType, CRCWidth>::Table(Parameters<CRCType, CRCWidth> && parameters) :
+    parameters(::std::move(parameters))
+{
+    InitTable();
+}
+#endif
+
+/**
+    @brief Gets the CRC parameters used to construct the CRC table
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+    @return CRC parameters
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline const CRC::Parameters<CRCType, CRCWidth> & CRC::Table<CRCType, CRCWidth>::GetParameters() const
+{
+    return parameters;
+}
+
+/**
+    @brief Gets the CRC table
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+    @return CRC table
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline const CRCType * CRC::Table<CRCType, CRCWidth>::GetTable() const
+{
+    return table;
+}
+
+/**
+    @brief Gets an entry in the CRC table
+    @param[in] index Index into the CRC table
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+    @return CRC table entry
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline CRCType CRC::Table<CRCType, CRCWidth>::operator[](unsigned char index) const
+{
+    return table[index];
+}
+
+/**
+    @brief Initializes a CRC table.
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline void CRC::Table<CRCType, CRCWidth>::InitTable()
+{
+    // For masking off the bits for the CRC (in the event that the number of bits in CRCType is larger than CRCWidth)
+    static crcpp_constexpr CRCType BIT_MASK((CRCType(1) << (CRCWidth - CRCType(1))) |
+                                           ((CRCType(1) << (CRCWidth - CRCType(1))) - CRCType(1)));
+
+    static crcpp_constexpr CRCType SHIFT(CRC::BoundedConstexprValue(CHAR_BIT - CRCWidth));
+
+    CRCType crc;
+    unsigned char byte = 0;
+
+    // Loop over each dividend (each possible number storable in an unsigned char)
+    do
+    {
+        crc = CRC::CalculateRemainder<CRCType, CRCWidth>(&byte, sizeof(byte), parameters, CRCType(0));
+
+        // This mask might not be necessary; all unit tests pass with this line commented out,
+        // but that might just be a coincidence based on the CRC parameters used for testing.
+        // In any case, this is harmless to leave in and only adds a single machine instruction per loop iteration.
+        crc &= BIT_MASK;
+
+        if (!parameters.reflectInput && CRCWidth < CHAR_BIT)
+        {
+            // Undo the special operation at the end of the CalculateRemainder()
+            // function for non-reflected CRCs < CHAR_BIT.
+            crc <<= SHIFT;
+        }
+
+        table[byte] = crc;
+    }
+    while (++byte);
+}
+
+/**
+    @brief Computes a CRC.
+    @param[in] data Data over which CRC will be computed
+    @param[in] size Size of the data
+    @param[in] parameters CRC parameters
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+    @return CRC
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline CRCType CRC::Calculate(const void * data, crcpp_size size, const Parameters<CRCType, CRCWidth> & parameters)
+{
+    CRCType remainder = CalculateRemainder(data, size, parameters, parameters.initialValue);
+
+    // No need to mask the remainder here; the mask will be applied in the Finalize() function.
+
+    return Finalize<CRCType, CRCWidth>(remainder, parameters.finalXOR, parameters.reflectInput != parameters.reflectOutput);
+}
+/**
+    @brief Appends additional data to a previous CRC calculation.
+    @note This function can be used to compute multi-part CRCs.
+    @param[in] data Data over which CRC will be computed
+    @param[in] size Size of the data
+    @param[in] parameters CRC parameters
+    @param[in] crc CRC from a previous calculation
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+    @return CRC
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline CRCType CRC::Calculate(const void * data, crcpp_size size, const Parameters<CRCType, CRCWidth> & parameters, CRCType crc)
+{
+    CRCType remainder = UndoFinalize<CRCType, CRCWidth>(crc, parameters.finalXOR, parameters.reflectInput != parameters.reflectOutput);
+
+    remainder = CalculateRemainder(data, size, parameters, remainder);
+
+    // No need to mask the remainder here; the mask will be applied in the Finalize() function.
+
+    return Finalize<CRCType, CRCWidth>(remainder, parameters.finalXOR, parameters.reflectInput != parameters.reflectOutput);
+}
+
+/**
+    @brief Computes a CRC via a lookup table.
+    @param[in] data Data over which CRC will be computed
+    @param[in] size Size of the data
+    @param[in] lookupTable CRC lookup table
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+    @return CRC
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline CRCType CRC::Calculate(const void * data, crcpp_size size, const Table<CRCType, CRCWidth> & lookupTable)
+{
+    const Parameters<CRCType, CRCWidth> & parameters = lookupTable.GetParameters();
+
+    CRCType remainder = CalculateRemainder(data, size, lookupTable, parameters.initialValue);
+
+    // No need to mask the remainder here; the mask will be applied in the Finalize() function.
+
+    return Finalize<CRCType, CRCWidth>(remainder, parameters.finalXOR, parameters.reflectInput != parameters.reflectOutput);
+}
+
+/**
+    @brief Appends additional data to a previous CRC calculation using a lookup table.
+    @note This function can be used to compute multi-part CRCs.
+    @param[in] data Data over which CRC will be computed
+    @param[in] size Size of the data
+    @param[in] lookupTable CRC lookup table
+    @param[in] crc CRC from a previous calculation
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+    @return CRC
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline CRCType CRC::Calculate(const void * data, crcpp_size size, const Table<CRCType, CRCWidth> & lookupTable, CRCType crc)
+{
+    const Parameters<CRCType, CRCWidth> & parameters = lookupTable.GetParameters();
+
+    CRCType remainder = UndoFinalize<CRCType, CRCWidth>(crc, parameters.finalXOR, parameters.reflectInput != parameters.reflectOutput);
+
+    remainder = CalculateRemainder(data, size, lookupTable, remainder);
+
+    // No need to mask the remainder here; the mask will be applied in the Finalize() function.
+
+    return Finalize<CRCType, CRCWidth>(remainder, parameters.finalXOR, parameters.reflectInput != parameters.reflectOutput);
+}
+
+/**
+    @brief Reflects (i.e. reverses the bits within) an integer value.
+    @param[in] value Value to reflect
+    @param[in] numBits Number of bits in the integer which will be reflected
+    @tparam IntegerType Integer type of the value being reflected
+    @return Reflected value
+*/
+template <typename IntegerType>
+inline IntegerType CRC::Reflect(IntegerType value, crcpp_uint16 numBits)
+{
+    IntegerType reversedValue(0);
+
+    for (crcpp_uint16 i = 0; i < numBits; ++i)
+    {
+        reversedValue = (reversedValue << 1) | (value & 1);
+        value >>= 1;
+    }
+
+    return reversedValue;
+}
+
+/**
+    @brief Computes the final reflection and XOR of a CRC remainder.
+    @param[in] remainder CRC remainder to reflect and XOR
+    @param[in] finalXOR Final value to XOR with the remainder
+    @param[in] reflectOutput true to reflect each byte of the remainder before the XOR
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+    @return Final CRC
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline CRCType CRC::Finalize(CRCType remainder, CRCType finalXOR, bool reflectOutput)
+{
+    // For masking off the bits for the CRC (in the event that the number of bits in CRCType is larger than CRCWidth)
+    static crcpp_constexpr CRCType BIT_MASK = (CRCType(1) << (CRCWidth - CRCType(1))) |
+                                             ((CRCType(1) << (CRCWidth - CRCType(1))) - CRCType(1));
+
+    if (reflectOutput)
+    {
+        remainder = Reflect(remainder, CRCWidth);
+    }
+
+    return (remainder ^ finalXOR) & BIT_MASK;
+}
+
+/**
+    @brief Undoes the process of computing the final reflection and XOR of a CRC remainder.
+    @note This function allows for computation of multi-part CRCs
+    @note Calling UndoFinalize() followed by Finalize() (or vice versa) will always return the original remainder value:
+
+        CRCType x = ...;
+        CRCType y = Finalize(x, finalXOR, reflectOutput);
+        CRCType z = UndoFinalize(y, finalXOR, reflectOutput);
+        assert(x == z);
+
+    @param[in] crc Reflected and XORed CRC
+    @param[in] finalXOR Final value XORed with the remainder
+    @param[in] reflectOutput true if the remainder is to be reflected
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+    @return Un-finalized CRC remainder
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline CRCType CRC::UndoFinalize(CRCType crc, CRCType finalXOR, bool reflectOutput)
+{
+    // For masking off the bits for the CRC (in the event that the number of bits in CRCType is larger than CRCWidth)
+    static crcpp_constexpr CRCType BIT_MASK = (CRCType(1) << (CRCWidth - CRCType(1))) |
+                                             ((CRCType(1) << (CRCWidth - CRCType(1))) - CRCType(1));
+
+    crc = (crc & BIT_MASK) ^ finalXOR;
+
+    if (reflectOutput)
+    {
+        crc = Reflect(crc, CRCWidth);
+    }
+
+    return crc;
+}
+
+/**
+    @brief Computes a CRC remainder.
+    @param[in] data Data over which the remainder will be computed
+    @param[in] size Size of the data
+    @param[in] parameters CRC parameters
+    @param[in] remainder Running CRC remainder. Can be an initial value or the result of a previous CRC remainder calculation.
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+    @return CRC remainder
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline CRCType CRC::CalculateRemainder(const void * data, crcpp_size size, const Parameters<CRCType, CRCWidth> & parameters, CRCType remainder)
+{
+#ifdef CRCPP_USE_CPP11
+    // This static_assert is put here because this function will always be compiled in no matter what
+    // the template parameters are and whether or not a table lookup or bit-by-bit algorithm is used.
+    static_assert(::std::numeric_limits<CRCType>::digits >= CRCWidth, "CRCType is too small to contain a CRC of width CRCWidth.");
+#else
+    // Catching this compile-time error is very important. Sadly, the compiler error will be very cryptic, but it's
+    // better than nothing.
+    enum { static_assert_failed_CRCType_is_too_small_to_contain_a_CRC_of_width_CRCWidth = 1 / (::std::numeric_limits<CRCType>::digits >= CRCWidth ? 1 : 0) };
+#endif
+
+    const unsigned char * current = reinterpret_cast<const unsigned char *>(data);
+
+    // Slightly different implementations based on the parameters. The current implementations try to eliminate as much
+    // computation from the inner loop (looping over each bit) as possible.
+    if (parameters.reflectInput)
+    {
+        CRCType polynomial = CRC::Reflect(parameters.polynomial, CRCWidth);
+        while (size--)
+        {
+            remainder ^= *current++;
+
+            // An optimizing compiler might choose to unroll this loop.
+            for (crcpp_size i = 0; i < CHAR_BIT; ++i)
+            {
+#ifdef CRCPP_BRANCHLESS
+                // Clever way to avoid a branch at the expense of a multiplication. This code is equivalent to the following:
+                // if (remainder & 1)
+                //     remainder = (remainder >> 1) ^ polynomial;
+                // else
+                //     remainder >>= 1;
+                remainder = (remainder >> 1) ^ ((remainder & 1) * polynomial);
+#else
+                remainder = (remainder & 1) ? ((remainder >> 1) ^ polynomial) : (remainder >> 1);
+#endif
+            }
+        }
+    }
+    else if (CRCWidth >= CHAR_BIT)
+    {
+        static crcpp_constexpr CRCType CRC_WIDTH_MINUS_ONE(CRCWidth - CRCType(1));
+#ifndef CRCPP_BRANCHLESS
+        static crcpp_constexpr CRCType CRC_HIGHEST_BIT_MASK(CRCType(1) << CRC_WIDTH_MINUS_ONE);
+#endif
+        static crcpp_constexpr CRCType SHIFT(BoundedConstexprValue(CRCWidth - CHAR_BIT));
+
+        while (size--)
+        {
+            remainder ^= (static_cast<CRCType>(*current++) << SHIFT);
+
+            // An optimizing compiler might choose to unroll this loop.
+            for (crcpp_size i = 0; i < CHAR_BIT; ++i)
+            {
+#ifdef CRCPP_BRANCHLESS
+                // Clever way to avoid a branch at the expense of a multiplication. This code is equivalent to the following:
+                // if (remainder & CRC_HIGHEST_BIT_MASK)
+                //     remainder = (remainder << 1) ^ parameters.polynomial;
+                // else
+                //     remainder <<= 1;
+                remainder = (remainder << 1) ^ (((remainder >> CRC_WIDTH_MINUS_ONE) & 1) * parameters.polynomial);
+#else
+                remainder = (remainder & CRC_HIGHEST_BIT_MASK) ? ((remainder << 1) ^ parameters.polynomial) : (remainder << 1);
+#endif
+            }
+        }
+    }
+    else
+    {
+        static crcpp_constexpr CRCType CHAR_BIT_MINUS_ONE(CHAR_BIT - 1);
+#ifndef CRCPP_BRANCHLESS
+        static crcpp_constexpr CRCType CHAR_BIT_HIGHEST_BIT_MASK(CRCType(1) << CHAR_BIT_MINUS_ONE);
+#endif
+        static crcpp_constexpr CRCType SHIFT(BoundedConstexprValue(CHAR_BIT - CRCWidth));
+
+        CRCType polynomial = parameters.polynomial << SHIFT;
+        remainder <<= SHIFT;
+
+        while (size--)
+        {
+            remainder ^= *current++;
+
+            // An optimizing compiler might choose to unroll this loop.
+            for (crcpp_size i = 0; i < CHAR_BIT; ++i)
+            {
+#ifdef CRCPP_BRANCHLESS
+                // Clever way to avoid a branch at the expense of a multiplication. This code is equivalent to the following:
+                // if (remainder & CHAR_BIT_HIGHEST_BIT_MASK)
+                //     remainder = (remainder << 1) ^ polynomial;
+                // else
+                //     remainder <<= 1;
+                remainder = (remainder << 1) ^ (((remainder >> CHAR_BIT_MINUS_ONE) & 1) * polynomial);
+#else
+                remainder = (remainder & CHAR_BIT_HIGHEST_BIT_MASK) ? ((remainder << 1) ^ polynomial) : (remainder << 1);
+#endif
+            }
+        }
+
+        remainder >>= SHIFT;
+    }
+
+    return remainder;
+}
+
+/**
+    @brief Computes a CRC remainder using lookup table.
+    @param[in] data Data over which the remainder will be computed
+    @param[in] size Size of the data
+    @param[in] lookupTable CRC lookup table
+    @param[in] remainder Running CRC remainder. Can be an initial value or the result of a previous CRC remainder calculation.
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+    @return CRC remainder
+*/
+template <typename CRCType, crcpp_uint16 CRCWidth>
+inline CRCType CRC::CalculateRemainder(const void * data, crcpp_size size, const Table<CRCType, CRCWidth> & lookupTable, CRCType remainder)
+{
+    const unsigned char * current = reinterpret_cast<const unsigned char *>(data);
+
+    if (lookupTable.GetParameters().reflectInput)
+    {
+        while (size--)
+        {
+#if defined(WIN32) || defined(_WIN32) || defined(WINCE)
+    // Disable warning about data loss when doing (remainder >> CHAR_BIT) when
+    // remainder is one byte long. The algorithm is still correct in this case,
+    // though it's possible that one additional machine instruction will be executed.
+#   pragma warning (push)
+#   pragma warning (disable : 4333)
+#endif
+            remainder = (remainder >> CHAR_BIT) ^ lookupTable[static_cast<unsigned char>(remainder ^ *current++)];
+#if defined(WIN32) || defined(_WIN32) || defined(WINCE)
+#   pragma warning (pop)
+#endif
+        }
+    }
+    else if (CRCWidth >= CHAR_BIT)
+    {
+        static crcpp_constexpr CRCType SHIFT(BoundedConstexprValue(CRCWidth - CHAR_BIT));
+
+        while (size--)
+        {
+            remainder = (remainder << CHAR_BIT) ^ lookupTable[static_cast<unsigned char>((remainder >> SHIFT) ^ *current++)];
+        }
+    }
+    else
+    {
+        static crcpp_constexpr CRCType SHIFT(BoundedConstexprValue(CHAR_BIT - CRCWidth));
+
+        remainder <<= SHIFT;
+
+        while (size--)
+        {
+            // Note: no need to mask here since remainder is guaranteed to fit in a single byte.
+            remainder = lookupTable[static_cast<unsigned char>(remainder ^ *current++)];
+        }
+
+        remainder >>= SHIFT;
+    }
+
+    return remainder;
+}
+
+/**
+    @brief Function to force a compile-time expression to be >= 0.
+    @note This function is used to avoid compiler warnings because all constexpr values are evaluated
+        in a function even in a branch will never be executed. This also means we don't need pragmas
+        to get rid of warnings, but it still can be computed at compile-time. Win-win!
+    @param[in] x Compile-time expression to bound
+    @tparam CRCType Integer type for storing the CRC result
+    @tparam CRCWidth Number of bits in the CRC
+    @return Non-negative compile-time expression
+*/
+template <typename IntegerType>
+inline crcpp_constexpr IntegerType CRC::BoundedConstexprValue(IntegerType x)
+{
+    return (x < IntegerType(0)) ? IntegerType(0) : x;
+}
+
+#ifdef CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+/**
+    @brief Returns a set of parameters for CRC-4 ITU.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-4 ITU has the following parameters and check value:
+        - polynomial     = 0x3
+        - initial value  = 0x0
+        - final XOR      = 0x0
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0x7
+    @return CRC-4 ITU parameters
+*/
+inline const CRC::Parameters<crcpp_uint8, 4> & CRC::CRC_4_ITU()
+{
+    static const Parameters<crcpp_uint8, 4> parameters = { 0x3, 0x0, 0x0, true, true };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-5 EPC.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-5 EPC has the following parameters and check value:
+        - polynomial     = 0x09
+        - initial value  = 0x09
+        - final XOR      = 0x00
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x00
+    @return CRC-5 EPC parameters
+*/
+inline const CRC::Parameters<crcpp_uint8, 5> & CRC::CRC_5_EPC()
+{
+    static const Parameters<crcpp_uint8, 5> parameters = { 0x09, 0x09, 0x00, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-5 ITU.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-5 ITU has the following parameters and check value:
+        - polynomial     = 0x15
+        - initial value  = 0x00
+        - final XOR      = 0x00
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0x07
+    @return CRC-5 ITU parameters
+*/
+inline const CRC::Parameters<crcpp_uint8, 5> & CRC::CRC_5_ITU()
+{
+    static const Parameters<crcpp_uint8, 5> parameters = { 0x15, 0x00, 0x00, true, true };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-5 USB.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-5 USB has the following parameters and check value:
+        - polynomial     = 0x05
+        - initial value  = 0x1F
+        - final XOR      = 0x1F
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0x19
+    @return CRC-5 USB parameters
+*/
+inline const CRC::Parameters<crcpp_uint8, 5> & CRC::CRC_5_USB()
+{
+    static const Parameters<crcpp_uint8, 5> parameters = { 0x05, 0x1F, 0x1F, true, true };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-6 CDMA2000-A.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-6 CDMA2000-A has the following parameters and check value:
+        - polynomial     = 0x27
+        - initial value  = 0x3F
+        - final XOR      = 0x00
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x0D
+    @return CRC-6 CDMA2000-A parameters
+*/
+inline const CRC::Parameters<crcpp_uint8, 6> & CRC::CRC_6_CDMA2000A()
+{
+    static const Parameters<crcpp_uint8, 6> parameters = { 0x27, 0x3F, 0x00, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-6 CDMA2000-B.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-6 CDMA2000-A has the following parameters and check value:
+        - polynomial     = 0x07
+        - initial value  = 0x3F
+        - final XOR      = 0x00
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x3B
+    @return CRC-6 CDMA2000-B parameters
+*/
+inline const CRC::Parameters<crcpp_uint8, 6> & CRC::CRC_6_CDMA2000B()
+{
+    static const Parameters<crcpp_uint8, 6> parameters = { 0x07, 0x3F, 0x00, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-6 ITU.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-6 ITU has the following parameters and check value:
+        - polynomial     = 0x03
+        - initial value  = 0x00
+        - final XOR      = 0x00
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0x06
+    @return CRC-6 ITU parameters
+*/
+inline const CRC::Parameters<crcpp_uint8, 6> & CRC::CRC_6_ITU()
+{
+    static const Parameters<crcpp_uint8, 6> parameters = { 0x03, 0x00, 0x00, true, true };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-7 JEDEC.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-7 JEDEC has the following parameters and check value:
+        - polynomial     = 0x09
+        - initial value  = 0x00
+        - final XOR      = 0x00
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x75
+    @return CRC-7 JEDEC parameters
+*/
+inline const CRC::Parameters<crcpp_uint8, 7> & CRC::CRC_7()
+{
+    static const Parameters<crcpp_uint8, 7> parameters = { 0x09, 0x00, 0x00, false, false };
+    return parameters;
+}
+#endif // CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+
+/**
+    @brief Returns a set of parameters for CRC-8 SMBus.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-8 SMBus has the following parameters and check value:
+        - polynomial     = 0x07
+        - initial value  = 0x00
+        - final XOR      = 0x00
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0xF4
+    @return CRC-8 SMBus parameters
+*/
+inline const CRC::Parameters<crcpp_uint8, 8> & CRC::CRC_8()
+{
+    static const Parameters<crcpp_uint8, 8> parameters = { 0x07, 0x00, 0x00, false, false };
+    return parameters;
+}
+
+#ifdef CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+/**
+    @brief Returns a set of parameters for CRC-8 EBU (aka CRC-8 AES).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-8 EBU has the following parameters and check value:
+        - polynomial     = 0x1D
+        - initial value  = 0xFF
+        - final XOR      = 0x00
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0x97
+    @return CRC-8 EBU parameters
+*/
+inline const CRC::Parameters<crcpp_uint8, 8> & CRC::CRC_8_EBU()
+{
+    static const Parameters<crcpp_uint8, 8> parameters = { 0x1D, 0xFF, 0x00, true, true };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-8 MAXIM (aka CRC-8 DOW-CRC).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-8 MAXIM has the following parameters and check value:
+        - polynomial     = 0x31
+        - initial value  = 0x00
+        - final XOR      = 0x00
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0xA1
+    @return CRC-8 MAXIM parameters
+*/
+inline const CRC::Parameters<crcpp_uint8, 8> & CRC::CRC_8_MAXIM()
+{
+    static const Parameters<crcpp_uint8, 8> parameters = { 0x31, 0x00, 0x00, true, true };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-8 WCDMA.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-8 WCDMA has the following parameters and check value:
+        - polynomial     = 0x9B
+        - initial value  = 0x00
+        - final XOR      = 0x00
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0x25
+    @return CRC-8 WCDMA parameters
+*/
+inline const CRC::Parameters<crcpp_uint8, 8> & CRC::CRC_8_WCDMA()
+{
+    static const Parameters<crcpp_uint8, 8> parameters = { 0x9B, 0x00, 0x00, true, true };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-10 ITU.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-10 ITU has the following parameters and check value:
+        - polynomial     = 0x233
+        - initial value  = 0x000
+        - final XOR      = 0x000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x199
+    @return CRC-10 ITU parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 10> & CRC::CRC_10()
+{
+    static const Parameters<crcpp_uint16, 10> parameters = { 0x233, 0x000, 0x000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-10 CDMA2000.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-10 CDMA2000 has the following parameters and check value:
+        - polynomial     = 0x3D9
+        - initial value  = 0x3FF
+        - final XOR      = 0x000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x233
+    @return CRC-10 CDMA2000 parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 10> & CRC::CRC_10_CDMA2000()
+{
+    static const Parameters<crcpp_uint16, 10> parameters = { 0x3D9, 0x3FF, 0x000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-11 FlexRay.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-11 FlexRay has the following parameters and check value:
+        - polynomial     = 0x385
+        - initial value  = 0x01A
+        - final XOR      = 0x000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x5A3
+    @return CRC-11 FlexRay parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 11> & CRC::CRC_11()
+{
+    static const Parameters<crcpp_uint16, 11> parameters = { 0x385, 0x01A, 0x000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-12 CDMA2000.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-12 CDMA2000 has the following parameters and check value:
+        - polynomial     = 0xF13
+        - initial value  = 0xFFF
+        - final XOR      = 0x000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0xD4D
+    @return CRC-12 CDMA2000 parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 12> & CRC::CRC_12_CDMA2000()
+{
+    static const Parameters<crcpp_uint16, 12> parameters = { 0xF13, 0xFFF, 0x000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-12 DECT (aka CRC-12 X-CRC).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-12 DECT has the following parameters and check value:
+        - polynomial     = 0x80F
+        - initial value  = 0x000
+        - final XOR      = 0x000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0xF5B
+    @return CRC-12 DECT parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 12> & CRC::CRC_12_DECT()
+{
+    static const Parameters<crcpp_uint16, 12> parameters = { 0x80F, 0x000, 0x000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-12 UMTS (aka CRC-12 3GPP).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-12 UMTS has the following parameters and check value:
+        - polynomial     = 0x80F
+        - initial value  = 0x000
+        - final XOR      = 0x000
+        - reflect input  = false
+        - reflect output = true
+        - check value    = 0xDAF
+    @return CRC-12 UMTS parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 12> & CRC::CRC_12_UMTS()
+{
+    static const Parameters<crcpp_uint16, 12> parameters = { 0x80F, 0x000, 0x000, false, true };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-13 BBC.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-13 BBC has the following parameters and check value:
+        - polynomial     = 0x1CF5
+        - initial value  = 0x0000
+        - final XOR      = 0x0000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x04FA
+    @return CRC-13 BBC parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 13> & CRC::CRC_13_BBC()
+{
+    static const Parameters<crcpp_uint16, 13> parameters = { 0x1CF5, 0x0000, 0x0000, false, false };
+   return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-15 CAN.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-15 CAN has the following parameters and check value:
+        - polynomial     = 0x4599
+        - initial value  = 0x0000
+        - final XOR      = 0x0000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x059E
+    @return CRC-15 CAN parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 15> & CRC::CRC_15()
+{
+    static const Parameters<crcpp_uint16, 15> parameters = { 0x4599, 0x0000, 0x0000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-15 MPT1327.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-15 MPT1327 has the following parameters and check value:
+        - polynomial     = 0x6815
+        - initial value  = 0x0000
+        - final XOR      = 0x0001
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x2566
+    @return CRC-15 MPT1327 parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 15> & CRC::CRC_15_MPT1327()
+{
+    static const Parameters<crcpp_uint16, 15> parameters = { 0x6815, 0x0000, 0x0001, false, false };
+    return parameters;
+}
+#endif // CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+
+/**
+    @brief Returns a set of parameters for CRC-16 ARC (aka CRC-16 IBM, CRC-16 LHA).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 ARC has the following parameters and check value:
+        - polynomial     = 0x8005
+        - initial value  = 0x0000
+        - final XOR      = 0x0000
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0xBB3D
+    @return CRC-16 ARC parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_ARC()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0x8005, 0x0000, 0x0000, true, true };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-16 BUYPASS (aka CRC-16 VERIFONE, CRC-16 UMTS).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 BUYPASS has the following parameters and check value:
+        - polynomial     = 0x8005
+        - initial value  = 0x0000
+        - final XOR      = 0x0000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0xFEE8
+    @return CRC-16 BUYPASS parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_BUYPASS()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0x8005, 0x0000, 0x0000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-16 CCITT FALSE.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 CCITT FALSE has the following parameters and check value:
+        - polynomial     = 0x1021
+        - initial value  = 0xFFFF
+        - final XOR      = 0x0000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x29B1
+    @return CRC-16 CCITT FALSE parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_CCITTFALSE()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0x1021, 0xFFFF, 0x0000, false, false };
+    return parameters;
+}
+
+#ifdef CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+/**
+    @brief Returns a set of parameters for CRC-16 CDMA2000.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 CDMA2000 has the following parameters and check value:
+        - polynomial     = 0xC867
+        - initial value  = 0xFFFF
+        - final XOR      = 0x0000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x4C06
+    @return CRC-16 CDMA2000 parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_CDMA2000()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0xC867, 0xFFFF, 0x0000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-16 DECT-R (aka CRC-16 R-CRC).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 DECT-R has the following parameters and check value:
+        - polynomial     = 0x0589
+        - initial value  = 0x0000
+        - final XOR      = 0x0001
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x007E
+    @return CRC-16 DECT-R parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_DECTR()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0x0589, 0x0000, 0x0001, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-16 DECT-X (aka CRC-16 X-CRC).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 DECT-X has the following parameters and check value:
+        - polynomial     = 0x0589
+        - initial value  = 0x0000
+        - final XOR      = 0x0000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x007F
+    @return CRC-16 DECT-X parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_DECTX()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0x0589, 0x0000, 0x0000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-16 DNP.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 DNP has the following parameters and check value:
+        - polynomial     = 0x3D65
+        - initial value  = 0x0000
+        - final XOR      = 0xFFFF
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0xEA82
+    @return CRC-16 DNP parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_DNP()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0x3D65, 0x0000, 0xFFFF, true, true };
+    return parameters;
+}
+#endif // CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+
+/**
+    @brief Returns a set of parameters for CRC-16 GENIBUS (aka CRC-16 EPC, CRC-16 I-CODE, CRC-16 DARC).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 GENIBUS has the following parameters and check value:
+        - polynomial     = 0x1021
+        - initial value  = 0xFFFF
+        - final XOR      = 0xFFFF
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0xD64E
+    @return CRC-16 GENIBUS parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_GENIBUS()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0x1021, 0xFFFF, 0xFFFF, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-16 KERMIT (aka CRC-16 CCITT, CRC-16 CCITT-TRUE).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 KERMIT has the following parameters and check value:
+        - polynomial     = 0x1021
+        - initial value  = 0x0000
+        - final XOR      = 0x0000
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0x2189
+    @return CRC-16 KERMIT parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_KERMIT()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0x1021, 0x0000, 0x0000, true, true };
+    return parameters;
+}
+
+#ifdef CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+/**
+    @brief Returns a set of parameters for CRC-16 MAXIM.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 MAXIM has the following parameters and check value:
+        - polynomial     = 0x8005
+        - initial value  = 0x0000
+        - final XOR      = 0xFFFF
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0x44C2
+    @return CRC-16 MAXIM parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_MAXIM()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0x8005, 0x0000, 0xFFFF, true, true };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-16 MODBUS.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 MODBUS has the following parameters and check value:
+        - polynomial     = 0x8005
+        - initial value  = 0xFFFF
+        - final XOR      = 0x0000
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0x4B37
+    @return CRC-16 MODBUS parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_MODBUS()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0x8005, 0xFFFF, 0x0000, true, true };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-16 T10-DIF.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 T10-DIF has the following parameters and check value:
+        - polynomial     = 0x8BB7
+        - initial value  = 0x0000
+        - final XOR      = 0x0000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0xD0DB
+    @return CRC-16 T10-DIF parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_T10DIF()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0x8BB7, 0x0000, 0x0000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-16 USB.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 USB has the following parameters and check value:
+        - polynomial     = 0x8005
+        - initial value  = 0xFFFF
+        - final XOR      = 0xFFFF
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0xB4C8
+    @return CRC-16 USB parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_USB()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0x8005, 0xFFFF, 0xFFFF, true, true };
+    return parameters;
+}
+#endif // CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+
+/**
+    @brief Returns a set of parameters for CRC-16 X-25 (aka CRC-16 IBM-SDLC, CRC-16 ISO-HDLC, CRC-16 B).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 X-25 has the following parameters and check value:
+        - polynomial     = 0x1021
+        - initial value  = 0xFFFF
+        - final XOR      = 0xFFFF
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0x906E
+    @return CRC-16 X-25 parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_X25()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0x1021, 0xFFFF, 0xFFFF, true, true };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-16 XMODEM (aka CRC-16 ZMODEM, CRC-16 ACORN, CRC-16 LTE).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-16 XMODEM has the following parameters and check value:
+        - polynomial     = 0x1021
+        - initial value  = 0x0000
+        - final XOR      = 0x0000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x31C3
+    @return CRC-16 XMODEM parameters
+*/
+inline const CRC::Parameters<crcpp_uint16, 16> & CRC::CRC_16_XMODEM()
+{
+    static const Parameters<crcpp_uint16, 16> parameters = { 0x1021, 0x0000, 0x0000, false, false };
+    return parameters;
+}
+
+#ifdef CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+/**
+    @brief Returns a set of parameters for CRC-17 CAN.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-17 CAN has the following parameters and check value:
+        - polynomial     = 0x1685B
+        - initial value  = 0x00000
+        - final XOR      = 0x00000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x04F03
+    @return CRC-17 CAN parameters
+*/
+inline const CRC::Parameters<crcpp_uint32, 17> & CRC::CRC_17_CAN()
+{
+    static const Parameters<crcpp_uint32, 17> parameters = { 0x1685B, 0x00000, 0x00000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-21 CAN.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-21 CAN has the following parameters and check value:
+        - polynomial     = 0x102899
+        - initial value  = 0x000000
+        - final XOR      = 0x000000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x0ED841
+    @return CRC-21 CAN parameters
+*/
+inline const CRC::Parameters<crcpp_uint32, 21> & CRC::CRC_21_CAN()
+{
+    static const Parameters<crcpp_uint32, 21> parameters = { 0x102899, 0x000000, 0x000000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-24 OPENPGP.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-24 OPENPGP has the following parameters and check value:
+        - polynomial     = 0x864CFB
+        - initial value  = 0xB704CE
+        - final XOR      = 0x000000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x21CF02
+    @return CRC-24 OPENPGP parameters
+*/
+inline const CRC::Parameters<crcpp_uint32, 24> & CRC::CRC_24()
+{
+    static const Parameters<crcpp_uint32, 24> parameters = { 0x864CFB, 0xB704CE, 0x000000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-24 FlexRay-A.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-24 FlexRay-A has the following parameters and check value:
+        - polynomial     = 0x5D6DCB
+        - initial value  = 0xFEDCBA
+        - final XOR      = 0x000000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x7979BD
+    @return CRC-24 FlexRay-A parameters
+*/
+inline const CRC::Parameters<crcpp_uint32, 24> & CRC::CRC_24_FLEXRAYA()
+{
+    static const Parameters<crcpp_uint32, 24> parameters = { 0x5D6DCB, 0xFEDCBA, 0x000000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-24 FlexRay-B.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-24 FlexRay-B has the following parameters and check value:
+        - polynomial     = 0x5D6DCB
+        - initial value  = 0xABCDEF
+        - final XOR      = 0x000000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x1F23B8
+    @return CRC-24 FlexRay-B parameters
+*/
+inline const CRC::Parameters<crcpp_uint32, 24> & CRC::CRC_24_FLEXRAYB()
+{
+    static const Parameters<crcpp_uint32, 24> parameters = { 0x5D6DCB, 0xABCDEF, 0x000000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-30 CDMA.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-30 CDMA has the following parameters and check value:
+        - polynomial     = 0x2030B9C7
+        - initial value  = 0x3FFFFFFF
+        - final XOR      = 0x00000000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x3B3CB540
+    @return CRC-30 CDMA parameters
+*/
+inline const CRC::Parameters<crcpp_uint32, 30> & CRC::CRC_30()
+{
+    static const Parameters<crcpp_uint32, 30> parameters = { 0x2030B9C7, 0x3FFFFFFF, 0x00000000, false, false };
+    return parameters;
+}
+#endif // CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+
+/**
+    @brief Returns a set of parameters for CRC-32 (aka CRC-32 ADCCP, CRC-32 PKZip).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-32 has the following parameters and check value:
+        - polynomial     = 0x04C11DB7
+        - initial value  = 0xFFFFFFFF
+        - final XOR      = 0xFFFFFFFF
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0xCBF43926
+    @return CRC-32 parameters
+*/
+inline const CRC::Parameters<crcpp_uint32, 32> & CRC::CRC_32()
+{
+    static const Parameters<crcpp_uint32, 32> parameters = { 0x04C11DB7, 0xFFFFFFFF, 0xFFFFFFFF, true, true };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-32 BZIP2 (aka CRC-32 AAL5, CRC-32 DECT-B, CRC-32 B-CRC).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-32 BZIP2 has the following parameters and check value:
+        - polynomial     = 0x04C11DB7
+        - initial value  = 0xFFFFFFFF
+        - final XOR      = 0xFFFFFFFF
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0xFC891918
+    @return CRC-32 BZIP2 parameters
+*/
+inline const CRC::Parameters<crcpp_uint32, 32> & CRC::CRC_32_BZIP2()
+{
+    static const Parameters<crcpp_uint32, 32> parameters = { 0x04C11DB7, 0xFFFFFFFF, 0xFFFFFFFF, false, false };
+    return parameters;
+}
+
+#ifdef CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+/**
+    @brief Returns a set of parameters for CRC-32 C (aka CRC-32 ISCSI, CRC-32 Castagnoli, CRC-32 Interlaken).
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-32 C has the following parameters and check value:
+        - polynomial     = 0x1EDC6F41
+        - initial value  = 0xFFFFFFFF
+        - final XOR      = 0xFFFFFFFF
+        - reflect input  = true
+        - reflect output = true
+        - check value    = 0xE3069283
+    @return CRC-32 C parameters
+*/
+inline const CRC::Parameters<crcpp_uint32, 32> & CRC::CRC_32_C()
+{
+    static const Parameters<crcpp_uint32, 32> parameters = { 0x1EDC6F41, 0xFFFFFFFF, 0xFFFFFFFF, true, true };
+    return parameters;
+}
+#endif
+
+/**
+    @brief Returns a set of parameters for CRC-32 MPEG-2.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-32 MPEG-2 has the following parameters and check value:
+        - polynomial     = 0x04C11DB7
+        - initial value  = 0xFFFFFFFF
+        - final XOR      = 0x00000000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x0376E6E7
+    @return CRC-32 MPEG-2 parameters
+*/
+inline const CRC::Parameters<crcpp_uint32, 32> & CRC::CRC_32_MPEG2()
+{
+    static const Parameters<crcpp_uint32, 32> parameters = { 0x04C11DB7, 0xFFFFFFFF, 0x00000000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-32 POSIX.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-32 POSIX has the following parameters and check value:
+        - polynomial     = 0x04C11DB7
+        - initial value  = 0x00000000
+        - final XOR      = 0xFFFFFFFF
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x765E7680
+    @return CRC-32 POSIX parameters
+*/
+inline const CRC::Parameters<crcpp_uint32, 32> & CRC::CRC_32_POSIX()
+{
+    static const Parameters<crcpp_uint32, 32> parameters = { 0x04C11DB7, 0x00000000, 0xFFFFFFFF, false, false };
+    return parameters;
+}
+
+#ifdef CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+/**
+    @brief Returns a set of parameters for CRC-32 Q.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-32 Q has the following parameters and check value:
+        - polynomial     = 0x814141AB
+        - initial value  = 0x00000000
+        - final XOR      = 0x00000000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x3010BF7F
+    @return CRC-32 Q parameters
+*/
+inline const CRC::Parameters<crcpp_uint32, 32> & CRC::CRC_32_Q()
+{
+    static const Parameters<crcpp_uint32, 32> parameters = { 0x814141AB, 0x00000000, 0x00000000, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-40 GSM.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-40 GSM has the following parameters and check value:
+        - polynomial     = 0x0004820009
+        - initial value  = 0x0000000000
+        - final XOR      = 0xFFFFFFFFFF
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0xD4164FC646
+    @return CRC-40 GSM parameters
+*/
+inline const CRC::Parameters<crcpp_uint64, 40> & CRC::CRC_40_GSM()
+{
+    static const Parameters<crcpp_uint64, 40> parameters = { 0x0004820009, 0x0000000000, 0xFFFFFFFFFF, false, false };
+    return parameters;
+}
+
+/**
+    @brief Returns a set of parameters for CRC-64 ECMA.
+    @note The parameters are static and are delayed-constructed to reduce memory footprint.
+    @note CRC-64 ECMA has the following parameters and check value:
+        - polynomial     = 0x42F0E1EBA9EA3693
+        - initial value  = 0x0000000000000000
+        - final XOR      = 0x0000000000000000
+        - reflect input  = false
+        - reflect output = false
+        - check value    = 0x6C40DF5F0B497347
+    @return CRC-64 ECMA parameters
+*/
+inline const CRC::Parameters<crcpp_uint64, 64> & CRC::CRC_64()
+{
+    static const Parameters<crcpp_uint64, 64> parameters = { 0x42F0E1EBA9EA3693, 0x0000000000000000, 0x0000000000000000, false, false };
+    return parameters;
+}
+#endif // CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+
+#ifdef CRCPP_USE_NAMESPACE
+}
+#endif
+
+#endif // CRCPP_CRC_H_

--- a/Common.hpp
+++ b/Common.hpp
@@ -42,6 +42,7 @@ namespace Procon {
 		RStick,
 		Home,
 		Share,
+		MaxButtons
 	};
 
 	enum class ButtonSource {

--- a/Controller.cpp
+++ b/Controller.cpp
@@ -40,20 +40,20 @@ namespace {
 
 #pragma pack(push, 1)
 	struct InputPacket {
-    uint8_t header;
-    uint8_t timer;
-    uint8_t info;
-		uint8_t rightButtons; 
+		uint8_t header;
+		uint8_t timer;
+		uint8_t info;
+		uint8_t rightButtons;
 		uint8_t middleButtons;
 		uint8_t leftButtons;
 		uint8_t sticks[6];
-    uint8_t vibrator;
-    uint16_t accel_1[3];
-    uint16_t gyro_1[3];
-    uint16_t accel_2[3];
-    uint16_t gyro_2[3];
-    uint16_t accel_3[3];
-    uint16_t gyro_3[3];
+		uint8_t vibrator;
+		uint16_t accel_1[3];
+		uint16_t gyro_1[3];
+		uint16_t accel_2[3];
+		uint16_t gyro_2[3];
+		uint16_t accel_3[3];
+		uint16_t gyro_3[3];
 	};
 #pragma pack(pop)
 
@@ -65,22 +65,22 @@ namespace {
 	void calibrateToRange(const StickPoint &stick, const StickRange &range, const StickPoint &center, short &outx, short &outy) {
 		constexpr short smax = std::numeric_limits<short>::max();
 		constexpr short smin = std::numeric_limits<short>::min();
-		
+
 		outx = static_cast<short>(
 			smax * std::clamp(
-				(static_cast<double>(stick.x) - center.x) / static_cast<double>(range.x.max - range.x.min) * 2.0,
+			(static_cast<double>(stick.x) - center.x) / static_cast<double>(range.x.max - range.x.min) * 2.0,
 				-1.0,
 				1.0
 			)
-			
-		);
+
+			);
 		outy = static_cast<short>(
 			smax *std::clamp(
-				(static_cast<double>(stick.y) - center.y) / static_cast<double>(range.y.max - range.y.min) * 2.0,
+			(static_cast<double>(stick.y) - center.y) / static_cast<double>(range.y.max - range.y.min) * 2.0,
 				-1.0,
 				1.0
 			)
-		);
+			);
 
 	}
 
@@ -145,7 +145,7 @@ namespace {
 		}
 	}
 
-	constexpr unsigned short buttonToReportBits(Button b){
+	constexpr unsigned short buttonToReportBits(Button b) {
 		switch (b) {
 		case Button::DPadUp:
 			return 0x0001;
@@ -184,45 +184,45 @@ namespace {
 		}
 	}
 
-  constexpr unsigned short buttonToReportBitsOld(Button b) {
-    switch (b) {
-    case Button::DPadUp:
-      return 0x0001;
-    case Button::DPadDown:
-      return 0x0002;
-    case Button::DPadLeft:
-      return 0x0004;
-    case Button::DPadRight:
-      return 0x0008;
-    case Button::Plus:
-      return 0x0010;
-    case Button::Minus:
-      return 0x0020;
-    case Button::LStick:
-      return 0x0040;
-    case Button::RStick:
-      return 0x0080;
-    case Button::L:
-      return 0x0100;
-    case Button::R:
-      return 0x0200;
-    case Button::Home:
-      return 0x0400; // Undocumented
+	constexpr unsigned short buttonToReportBitsOld(Button b) {
+		switch (b) {
+		case Button::DPadUp:
+			return 0x0001;
+		case Button::DPadDown:
+			return 0x0002;
+		case Button::DPadLeft:
+			return 0x0004;
+		case Button::DPadRight:
+			return 0x0008;
+		case Button::Plus:
+			return 0x0010;
+		case Button::Minus:
+			return 0x0020;
+		case Button::LStick:
+			return 0x0040;
+		case Button::RStick:
+			return 0x0080;
+		case Button::L:
+			return 0x0100;
+		case Button::R:
+			return 0x0200;
+		case Button::Home:
+			return 0x0400; // Undocumented
 
-    case Button::A:
-      return 0x1000;
-    case Button::B:
-      return 0x2000;
-    case Button::X:
-      return 0x4000;
-    case Button::Y:
-      return 0x8000;
-    default:
-      return 0x0000;
-    }
-  }
+		case Button::A:
+			return 0x1000;
+		case Button::B:
+			return 0x2000;
+		case Button::X:
+			return 0x4000;
+		case Button::Y:
+			return 0x8000;
+		default:
+			return 0x0000;
+		}
+	}
 
-  const std::string buttonConfigName{ "bMatchButtonLabels" };
+	const std::string buttonConfigName{ "bMatchButtonLabels" };
 
 	void mapButtonToState(Button b, ExpandedPadState &state) {
 		switch (b) {
@@ -236,13 +236,13 @@ namespace {
 			state.sharePressed = true;
 			return;
 		default:
-      if (Config::get<bool>(buttonConfigName).value_or(false)) {
-        state.xinState.wButtons |= buttonToReportBitsOld(b);
-      }
-      else {
-        state.xinState.wButtons |= buttonToReportBits(b);
-      }
-      return;
+			if (Config::get<bool>(buttonConfigName).value_or(false)) {
+				state.xinState.wButtons |= buttonToReportBitsOld(b);
+			}
+			else {
+				state.xinState.wButtons |= buttonToReportBits(b);
+			}
+			return;
 		}
 	}
 
@@ -317,26 +317,26 @@ namespace {
 #endif //#ifdef _DEBUG
 
 	void mapInputToState(const InputPacket &p, CalibrationData &cal, ExpandedPadState &state) {
-    auto uint16ToInt16 = [](uint16_t a) {return *(int16_t*)(&a); };
+		auto uint16ToInt16 = [](uint16_t a) {return *(int16_t*)(&a); };
 
-    state.leftStick.x = p.sticks[0] | ((p.sticks[1] & 0xF) << 8);
-    state.leftStick.y = (p.sticks[1] >> 4 | p.sticks[2] << 4);
-    state.rightStick.x = p.sticks[3] | ((p.sticks[4] & 0xF) << 8);
-    state.rightStick.y = (p.sticks[4] >> 4 | p.sticks[5] << 4);
+		state.leftStick.x = p.sticks[0] | ((p.sticks[1] & 0xF) << 8);
+		state.leftStick.y = (p.sticks[1] >> 4 | p.sticks[2] << 4);
+		state.rightStick.x = p.sticks[3] | ((p.sticks[4] & 0xF) << 8);
+		state.rightStick.y = (p.sticks[4] >> 4 | p.sticks[5] << 4);
 
-    state.accel.x = uint16ToInt16(p.accel_1[0]) * cal.motionSensor.accelCoeff[0];
-    state.accel.y = uint16ToInt16(p.accel_1[1]) * cal.motionSensor.accelCoeff[1];
-    state.accel.z = uint16ToInt16(p.accel_1[2]) * cal.motionSensor.accelCoeff[2];
+		state.accel.x = uint16ToInt16(p.accel_1[0]) * cal.motionSensor.accelCoeff[0];
+		state.accel.y = uint16ToInt16(p.accel_1[1]) * cal.motionSensor.accelCoeff[1];
+		state.accel.z = uint16ToInt16(p.accel_1[2]) * cal.motionSensor.accelCoeff[2];
 
-    state.gyro.x = uint16ToInt16(p.gyro_1[0]) * cal.motionSensor.gyroCoeff[0];
-    state.gyro.y = uint16ToInt16(p.gyro_1[1]) * cal.motionSensor.gyroCoeff[1];
-    state.gyro.z = uint16ToInt16(p.gyro_1[2]) * cal.motionSensor.gyroCoeff[2];
-		
+		state.gyro.x = uint16ToInt16(p.gyro_1[0]) * cal.motionSensor.gyroCoeff[0];
+		state.gyro.y = uint16ToInt16(p.gyro_1[1]) * cal.motionSensor.gyroCoeff[1];
+		state.gyro.z = uint16ToInt16(p.gyro_1[2]) * cal.motionSensor.gyroCoeff[2];
+
 		// Sets state.xinState's sticks
 		calibrateToRange(state.leftStick, cal.left, cal.leftCenter, state.xinState.sThumbLX, state.xinState.sThumbLY);
 		calibrateToRange(state.rightStick, cal.right, cal.rightCenter, state.xinState.sThumbRX, state.xinState.sThumbRY);
 
-		
+
 		pullButtonsFromByte(p.leftButtons, ButtonSource::Left, state.buttons);
 		pullButtonsFromByte(p.rightButtons, ButtonSource::Right, state.buttons);
 		pullButtonsFromByte(p.middleButtons, ButtonSource::Middle, state.buttons);
@@ -357,170 +357,170 @@ namespace {
 }; //namespace
 
 namespace Procon {
-  using std::array;
+	using std::array;
 
-  void SetDefaultCalibration(CalibrationData &dat) {
-    constexpr uchar ucmin = std::numeric_limits<uchar>::min();
-    constexpr uchar ucmax = std::numeric_limits<uchar>::max();
-    dat.leftCenter.x = ucmax / 2;
-    dat.leftCenter.y = ucmax / 2;
-    dat.rightCenter = dat.leftCenter;
-    dat.left.x.min = dat.leftCenter.x;
-    dat.left.x.max = dat.leftCenter.x;
-    dat.left.y = dat.left.x;
-    dat.right = dat.left;
-  }
+	void SetDefaultCalibration(CalibrationData &dat) {
+		constexpr uchar ucmin = std::numeric_limits<uchar>::min();
+		constexpr uchar ucmax = std::numeric_limits<uchar>::max();
+		dat.leftCenter.x = ucmax / 2;
+		dat.leftCenter.y = ucmax / 2;
+		dat.rightCenter = dat.leftCenter;
+		dat.left.x.min = dat.leftCenter.x;
+		dat.left.x.max = dat.leftCenter.x;
+		dat.left.y = dat.left.x;
+		dat.right = dat.left;
+	}
 
-  void HIDCloser::operator()(hid_device *ptr) {
-    if (ptr != nullptr)
-      hid_close(ptr);
-  }
-  void zeroPadState(ExpandedPadState &state) {
-    for (auto& button : state.buttons)
-    {
-      std::get<1>(button) = false;
-    }
-    state.xinState = { 0 };
-    state.leftStick = { 0 };
-    state.rightStick = { 0 };
-    state.accel = { 0, 0, 0 };
-    state.gyro = { 0, 0, 0 };
-    state.sharePressed = false;
-  }
+	void HIDCloser::operator()(hid_device *ptr) {
+		if (ptr != nullptr)
+			hid_close(ptr);
+	}
+	void zeroPadState(ExpandedPadState &state) {
+		for (auto& button : state.buttons)
+		{
+			std::get<1>(button) = false;
+		}
+		state.xinState = { 0 };
+		state.leftStick = { 0 };
+		state.rightStick = { 0 };
+		state.accel = { 0, 0, 0 };
+		state.gyro = { 0, 0, 0 };
+		state.sharePressed = false;
+	}
 
-  Controller::Controller(uchar port) :device(nullptr), port(port) {
-    SetDefaultCalibration(calib);
-  }
+	Controller::Controller(uchar port) :device(nullptr), port(port) {
+		SetDefaultCalibration(calib);
+	}
 
-  Controller::Controller(Controller &&) = default;
+	Controller::Controller(Controller &&) = default;
 
-  Controller& Controller::operator=(Controller &&) = default;
+	Controller& Controller::operator=(Controller &&) = default;
 
-  Controller::~Controller() {
-    if (_connected) {
-      XOutputUnPlug(port);
-    }
-    if (device) {
-      static const array<uchar, 2> disconnect{ 0x80, 0x05 };
-      exchange(disconnect);
-    }
-  }
+	Controller::~Controller() {
+		if (_connected) {
+			XOutputUnPlug(port);
+		}
+		if (device) {
+			static const array<uchar, 2> disconnect{ 0x80, 0x05 };
+			exchange(disconnect);
+		}
+	}
 
-  void Controller::openDevice(hid_device_info *dev) {
-    using namespace std::this_thread;
-    using namespace std::chrono;
+	void Controller::openDevice(hid_device_info *dev) {
+		using namespace std::this_thread;
+		using namespace std::chrono;
 
-    if (dev == nullptr)
-      throw ControllerException("Unable to open controller device: dev was nullptr.");
-    if (dev->product_id != Procon_ID)
-      throw ControllerException("Unable to open controller device: product id was not a Switch Pro Controller.");
-    if (wcscmp(dev->serial_number, L"000000000001") != 0)
-      throw ControllerException("Device is not connected via USB");
+		if (dev == nullptr)
+			throw ControllerException("Unable to open controller device: dev was nullptr.");
+		if (dev->product_id != Procon_ID)
+			throw ControllerException("Unable to open controller device: product id was not a Switch Pro Controller.");
+		if (wcscmp(dev->serial_number, L"000000000001") != 0)
+			throw ControllerException("Device is not connected via USB");
 
-    device.reset(hid_open_path(dev->path));
-    if (!device)
-      throw ControllerException("Unable to open controller device: device path could not be opened.");
+		device.reset(hid_open_path(dev->path));
+		if (!device)
+			throw ControllerException("Unable to open controller device: device path could not be opened.");
 
-    // Start handshake
-    if (!exchange(handshake)) {
-      throw ControllerException("Handshake failed.");
-    }
-    exchange(switchBaudrate);
-    exchange(handshake);
-    exchange(HIDOnlyMode);
+		// Start handshake
+		if (!exchange(handshake)) {
+			throw ControllerException("Handshake failed.");
+		}
+		exchange(switchBaudrate);
+		exchange(handshake);
+		exchange(HIDOnlyMode);
 
-    //sendSubcommand(0x1, rumbleCommand, enable);
-    // Set report mode to 0x30 (we now get the same data as in the bluetooth case)
-    std::array<uchar, 2> report{ 0x30, 0x00 };
-    sendSubcommand(0x01, 0x03, report);
-    sendSubcommand(0x01, imuDataCommand, enable);
-    sendSubcommand(0x01, ledCommand, led);
+		//sendSubcommand(0x1, rumbleCommand, enable);
+		// Set report mode to 0x30 (we now get the same data as in the bluetooth case)
+		std::array<uchar, 2> report{ 0x30, 0x00 };
+		sendSubcommand(0x01, 0x03, report);
+		sendSubcommand(0x01, imuDataCommand, enable);
+		sendSubcommand(0x01, ledCommand, led);
 
-    // Read calibration data (use factory calibration for now)
-    readAnalogStickCalibrationData();
-    readMotionSensorCalibrationData();
+		// Read calibration data (use factory calibration for now)
+		readAnalogStickCalibrationData();
+		readMotionSensorCalibrationData();
 
-    if (XOutputPlugIn(port) != ERROR_SUCCESS) {
-      device.reset(nullptr);
-      throw ControllerException("Unable to plugin XOutput controller.");
-    }
-    _connected = true;
-    sleep_for(milliseconds(100));
-    //updateStatus();
-  }
+		if (XOutputPlugIn(port) != ERROR_SUCCESS) {
+			device.reset(nullptr);
+			throw ControllerException("Unable to plugin XOutput controller.");
+		}
+		_connected = true;
+		sleep_for(milliseconds(100));
+		//updateStatus();
+	}
 
-  void Controller::readAnalogStickCalibrationData()
-  {
-    auto factory_stick_cal = getSpiData(0x603D, 0x12).value();
+	void Controller::readAnalogStickCalibrationData()
+	{
+		auto factory_stick_cal = getSpiData(0x603D, 0x12).value();
 
-    calib.leftCenter.x = (factory_stick_cal[4] << 8) & 0xF00 | factory_stick_cal[3];
-    calib.leftCenter.y = (factory_stick_cal[5] << 4) | (factory_stick_cal[4] >> 4);
-    calib.left.x.min = calib.leftCenter.x - ((factory_stick_cal[7] << 8) & 0xF00 | factory_stick_cal[6]);
-    calib.left.x.max = calib.leftCenter.x + ((factory_stick_cal[1] << 8) & 0xF00 | factory_stick_cal[0]);
-    calib.left.y.min = calib.leftCenter.y - ((factory_stick_cal[8] << 4) | (factory_stick_cal[7] >> 4));
-    calib.left.y.max = calib.leftCenter.y + ((factory_stick_cal[2] << 4) | (factory_stick_cal[1] >> 4));
+		calib.leftCenter.x = (factory_stick_cal[4] << 8) & 0xF00 | factory_stick_cal[3];
+		calib.leftCenter.y = (factory_stick_cal[5] << 4) | (factory_stick_cal[4] >> 4);
+		calib.left.x.min = calib.leftCenter.x - ((factory_stick_cal[7] << 8) & 0xF00 | factory_stick_cal[6]);
+		calib.left.x.max = calib.leftCenter.x + ((factory_stick_cal[1] << 8) & 0xF00 | factory_stick_cal[0]);
+		calib.left.y.min = calib.leftCenter.y - ((factory_stick_cal[8] << 4) | (factory_stick_cal[7] >> 4));
+		calib.left.y.max = calib.leftCenter.y + ((factory_stick_cal[2] << 4) | (factory_stick_cal[1] >> 4));
 
-    calib.rightCenter.x = (factory_stick_cal[10] << 8) & 0xF00 | factory_stick_cal[9];
-    calib.rightCenter.y = (factory_stick_cal[11] << 4) | (factory_stick_cal[10] >> 4);
-    calib.right.x.min = calib.rightCenter.x - ((factory_stick_cal[13] << 8) & 0xF00 | factory_stick_cal[12]);
-    calib.right.x.max = calib.rightCenter.x + ((factory_stick_cal[16] << 8) & 0xF00 | factory_stick_cal[15]);
-    calib.right.y.min = calib.rightCenter.y - ((factory_stick_cal[14] << 4) | (factory_stick_cal[13] >> 4));
-    calib.right.y.max = calib.rightCenter.y + ((factory_stick_cal[17] << 4) | (factory_stick_cal[16] >> 4));
-  }
+		calib.rightCenter.x = (factory_stick_cal[10] << 8) & 0xF00 | factory_stick_cal[9];
+		calib.rightCenter.y = (factory_stick_cal[11] << 4) | (factory_stick_cal[10] >> 4);
+		calib.right.x.min = calib.rightCenter.x - ((factory_stick_cal[13] << 8) & 0xF00 | factory_stick_cal[12]);
+		calib.right.x.max = calib.rightCenter.x + ((factory_stick_cal[16] << 8) & 0xF00 | factory_stick_cal[15]);
+		calib.right.y.min = calib.rightCenter.y - ((factory_stick_cal[14] << 4) | (factory_stick_cal[13] >> 4));
+		calib.right.y.max = calib.rightCenter.y + ((factory_stick_cal[17] << 4) | (factory_stick_cal[16] >> 4));
+	}
 
-  void Controller::readMotionSensorCalibrationData()
-  {
-    auto factory_sensor_cal = getSpiData(0x6020, 0x18).value();
-    auto uint16ToInt16 = [](uint16_t a) {return *(int16_t*)(&a); };
-    array<int16_t, 3> accel_cal
-    {
-      uint16ToInt16(factory_sensor_cal[0x00] | factory_sensor_cal[0x01] << 8),
-      uint16ToInt16(factory_sensor_cal[0x02] | factory_sensor_cal[0x03] << 8),
-      uint16ToInt16(factory_sensor_cal[0x04] | factory_sensor_cal[0x05] << 8)
-    };
+	void Controller::readMotionSensorCalibrationData()
+	{
+		auto factory_sensor_cal = getSpiData(0x6020, 0x18).value();
+		auto uint16ToInt16 = [](uint16_t a) {return *(int16_t*)(&a); };
+		array<int16_t, 3> accel_cal
+		{
+			uint16ToInt16(factory_sensor_cal[0x00] | factory_sensor_cal[0x01] << 8),
+			uint16ToInt16(factory_sensor_cal[0x02] | factory_sensor_cal[0x03] << 8),
+			uint16ToInt16(factory_sensor_cal[0x04] | factory_sensor_cal[0x05] << 8)
+		};
 
-    array<int16_t, 3> gyro_cal
-    {
-      uint16ToInt16(factory_sensor_cal[0x0C] | factory_sensor_cal[0x0D] << 8),
-      uint16ToInt16(factory_sensor_cal[0x0E] | factory_sensor_cal[0x0F] << 8),
-      uint16ToInt16(factory_sensor_cal[0x10] | factory_sensor_cal[0x11] << 8)
-    };
+		array<int16_t, 3> gyro_cal
+		{
+			uint16ToInt16(factory_sensor_cal[0x0C] | factory_sensor_cal[0x0D] << 8),
+			uint16ToInt16(factory_sensor_cal[0x0E] | factory_sensor_cal[0x0F] << 8),
+			uint16ToInt16(factory_sensor_cal[0x10] | factory_sensor_cal[0x11] << 8)
+		};
 
-    calib.motionSensor.accelCoeff = {
-      (float)(1.0 / (float)(16384 - accel_cal[0])) * 4.0f/*  * 9.8f*/,
-      (float)(1.0 / (float)(16384 - accel_cal[1])) * 4.0f/*  * 9.8f*/,
-      (float)(1.0 / (float)(16384 - accel_cal[2])) * 4.0f/*  * 9.8f*/
-    };
+		calib.motionSensor.accelCoeff = {
+			(float)(1.0 / (float)(16384 - accel_cal[0])) * 4.0f/*  * 9.8f*/,
+			(float)(1.0 / (float)(16384 - accel_cal[1])) * 4.0f/*  * 9.8f*/,
+			(float)(1.0 / (float)(16384 - accel_cal[2])) * 4.0f/*  * 9.8f*/
+		};
 
-    calib.motionSensor.gyroCoeff = {
-      (float)(936.0 / (float)(13371 - gyro_cal[0])/* * 0.01745329251994*/),
-      (float)(936.0 / (float)(13371 - gyro_cal[1])/* * 0.01745329251994*/),
-      (float)(936.0 / (float)(13371 - gyro_cal[2])/* * 0.01745329251994*/)
-    };
-  }
+		calib.motionSensor.gyroCoeff = {
+			(float)(936.0 / (float)(13371 - gyro_cal[0])/* * 0.01745329251994*/),
+			(float)(936.0 / (float)(13371 - gyro_cal[1])/* * 0.01745329251994*/),
+			(float)(936.0 / (float)(13371 - gyro_cal[2])/* * 0.01745329251994*/)
+		};
+	}
 
 	void Controller::pollInput() {
 		if (!device)
 			return;
 
 		//auto dat = sendCommand(getInput, empty);
-    auto dat = receive(200);
-    if (!dat)
-    {
-      return;
-    }
+		auto dat = receive(200);
+		if (!dat)
+		{
+			return;
+		}
 
-		if  (dat.value()[0] == 0x30 || dat.value()[0] == 0x31 
-      || dat.value()[0] == 0x32 || dat.value()[0] == 0x33)
-    {
-      padStatus.lastStatus = clock::now();
+		if (dat.value()[0] == 0x30 || dat.value()[0] == 0x31
+			|| dat.value()[0] == 0x32 || dat.value()[0] == 0x33)
+		{
+			padStatus.lastStatus = clock::now();
 
 			InputPacket p;
 			memcpy(&p, dat.value().data(), sizeof(InputPacket));
 
 			zeroPadState(padStatus);
 			mapInputToState(p, calib, padStatus);
-			
+
 			DWORD err;
 			if ((err = XOutputSetState(port, &padStatus.xinState)) != ERROR_SUCCESS) {
 				std::string errMsg{ "XOutput Error: " };
@@ -528,7 +528,7 @@ namespace Procon {
 				throw ControllerException(errMsg);
 			}
 		}
-    //updateStatus();
+		//updateStatus();
 	}
 
 	bool Controller::connected() const {
@@ -558,17 +558,17 @@ namespace Procon {
 		lastStatus = clock::now();
 	}
 
-  Controller::exchangeArray Controller::receive(int timeout)
-  {
-    std::array<uchar, exchangeLen> ret;
-    ret.fill(0);
-    int retLen = hid_read_timeout(device.get(), ret.data(), exchangeLen, timeout);
-    if (retLen == 0)
-      return {};
-    return ret;
-  }
+	Controller::exchangeArray Controller::receive(int timeout)
+	{
+		std::array<uchar, exchangeLen> ret;
+		ret.fill(0);
+		int retLen = hid_read_timeout(device.get(), ret.data(), exchangeLen, timeout);
+		if (retLen == 0)
+			return {};
+		return ret;
+	}
 
-	Controller::exchangeArray Controller::sendRumble(uchar largeMotor, uchar smallMotor){
+	Controller::exchangeArray Controller::sendRumble(uchar largeMotor, uchar smallMotor) {
 		std::array<uchar, 9> buf{
 			static_cast<uchar>(rumbleCounter++ & 0xF),
 			0x80_uc,
@@ -591,27 +591,27 @@ namespace Procon {
 		return sendCommand(0x10, buf);
 	}
 
-  Controller::exchangeArray Controller::getSpiData(uint32_t offset, const uint8_t readLen)
-  {
-    std::array<uint8_t, 0x100> buf;
-    while (true)
-    {
-      buf.fill(0);
-      *(uint32_t*)(buf.data()) = offset;
-      *(uint8_t*)(buf.data() + 4) = readLen;
-      auto res = sendSubcommand(0x01, 0x10, buf);
-      //if (res && (*(uint16_t*)(res.value().data() + 0xD) == 0x1090) && (*(uint32_t*)(res.value().data() + 0xF) == offset)) // For bluetooth
-      if (res && (*(uint16_t*)(res.value().data() + 0x17) == 0x1090) && (*(uint32_t*)(res.value().data() + 0x19) == offset))
-      {
-        std::array<uchar, exchangeLen> ret;
-        ret.fill(0);
-        //memcpy(ret.data(), res.value().data() + 0x14, readLen); // For bluetooth
-        memcpy(ret.data(), res.value().data() + 0x1E, readLen);
-        return ret;
-      }
-    }
-    return {};
-  }
+	Controller::exchangeArray Controller::getSpiData(uint32_t offset, const uint8_t readLen)
+	{
+		std::array<uint8_t, 0x100> buf;
+		while (true)
+		{
+			buf.fill(0);
+			*(uint32_t*)(buf.data()) = offset;
+			*(uint8_t*)(buf.data() + 4) = readLen;
+			auto res = sendSubcommand(0x01, 0x10, buf);
+			//if (res && (*(uint16_t*)(res.value().data() + 0xD) == 0x1090) && (*(uint32_t*)(res.value().data() + 0xF) == offset)) // For bluetooth
+			if (res && (*(uint16_t*)(res.value().data() + 0x17) == 0x1090) && (*(uint32_t*)(res.value().data() + 0x19) == offset))
+			{
+				std::array<uchar, exchangeLen> ret;
+				ret.fill(0);
+				//memcpy(ret.data(), res.value().data() + 0x14, readLen); // For bluetooth
+				memcpy(ret.data(), res.value().data() + 0x1E, readLen);
+				return ret;
+			}
+		}
+		return {};
+	}
 
 	ControllerException::ControllerException(const std::string& what) : runtime_error(what) {}
 	ControllerException::ControllerException(const char* what) : runtime_error(what) {}

--- a/Controller.cpp
+++ b/Controller.cpp
@@ -7,7 +7,6 @@
 #endif
 #include <string>
 #include <limits>
-#include <vector>
 
 #include "hidapi.h"
 #include "XOutput.hpp"
@@ -15,47 +14,7 @@
 
 using namespace XOutput;
 
-namespace Procon {
-	using std::array;
 
-	void SetDefaultCalibration(CalibrationData &dat) {
-		constexpr uchar ucmin = std::numeric_limits<uchar>::min();
-		constexpr uchar ucmax = std::numeric_limits<uchar>::max();
-		dat.leftCenter.x = ucmax / 2;
-		dat.leftCenter.y = ucmax / 2;
-		dat.rightCenter = dat.leftCenter;
-		dat.left.x.min = dat.leftCenter.x;
-		dat.left.x.max = dat.leftCenter.x;
-		dat.left.y = dat.left.x;
-		dat.right = dat.left;
-	}
-
-	void HIDCloser::operator()(hid_device *ptr) {
-		if (ptr != nullptr)
-			hid_close(ptr);
-	}
-	void zeroPadState(ExpandedPadState &state) {
-		state.xinState = { 0 };
-		state.leftStick = { 0 };
-		state.rightStick = { 0 };
-		state.sharePressed = false;
-	}
-	Controller::Controller(uchar port) :device(nullptr), port(port) {
-		SetDefaultCalibration(calib);
-	}
-	Controller::Controller(Controller &&) = default;
-	Controller& Controller::operator=(Controller &&) = default;
-	Controller::~Controller() {
-		if (_connected) {
-			XOutputUnPlug(port);
-		}
-		if (device) {
-			static const array<uchar, 2> disconnect{ 0x80, 0x05 };
-			exchange(disconnect);
-		}
-	}
-
-};
 namespace {
 	using std::array;
 	using Procon::uchar;
@@ -79,14 +38,24 @@ namespace {
 	constexpr uchar getInput{ 0x1f };
 	const array<uchar, 0> empty{};
 
+#pragma pack(push, 1)
 	struct InputPacket {
-		uint8_t header[8];
-		uint8_t unknown[5];
-		uint8_t rightButtons;
+    uint8_t header;
+    uint8_t timer;
+    uint8_t info;
+		uint8_t rightButtons; 
 		uint8_t middleButtons;
 		uint8_t leftButtons;
 		uint8_t sticks[6];
+    uint8_t vibrator;
+    uint16_t accel_1[3];
+    uint16_t gyro_1[3];
+    uint16_t accel_2[3];
+    uint16_t gyro_2[3];
+    uint16_t accel_3[3];
+    uint16_t gyro_3[3];
 	};
+#pragma pack(pop)
 
 	constexpr double lerp(double min, double max, double t) {
 		return (1.0 - t) * min + t * max;
@@ -115,54 +84,6 @@ namespace {
 
 	}
 
-	short expandUChar(uchar c) {
-		constexpr uchar ucmax = std::numeric_limits<uchar>::max();
-		constexpr short smax = std::numeric_limits<short>::max();
-		constexpr short smin = std::numeric_limits<short>::min();
-
-		double d = std::clamp(static_cast<double>(c) / ucmax, 0.0, 1.0);
-		return static_cast<short>( lerp(smin, smax, d) );
-	}
-
-};
-namespace Procon {
-
-	void Controller::openDevice(hid_device_info *dev) {
-		using namespace std::this_thread;
-		using namespace std::chrono;
-
-		if (dev == nullptr)
-			throw ControllerException("Unable to open controller device: dev was nullptr.");
-		if (dev->product_id != Procon_ID)
-			throw ControllerException("Unable to open controller device: product id was not a Switch Pro Controller.");
-		device.reset(hid_open_path(dev->path));
-		if (!device)
-			throw ControllerException("Unable to open controller device: device path could not be opened.");
-		//vController.ProductId = dev->product_id;
-		//vController.VendorId = dev->vendor_id;
-		if (!exchange(handshake)) {
-			throw ControllerException("Handshake failed.");
-		}
-		exchange(switchBaudrate);
-		exchange(handshake);
-		exchange(HIDOnlyMode);
-		
-		
-		sendSubcommand(0x1, rumbleCommand, enable);
-		sendSubcommand(0x1, imuDataCommand, enable);
-		sendSubcommand(0x1, ledCommand, led);
-
-		if (XOutputPlugIn(port) != ERROR_SUCCESS) {
-			device.reset(nullptr);
-			throw ControllerException("Unable to plugin XOutput controller.");
-		}
-		_connected = true;
-		sleep_for(milliseconds(100));
-		//updateStatus();
-	}
-
-};
-namespace {
 	using std::vector;
 	using std::tuple;
 	using std::array;
@@ -262,45 +183,46 @@ namespace {
 			return 0x0000;
 		}
 	}
-	constexpr unsigned short buttonToReportBitsOld(Button b) {
-		switch (b) {
-		case Button::DPadUp:
-			return 0x0001;
-		case Button::DPadDown:
-			return 0x0002;
-		case Button::DPadLeft:
-			return 0x0004;
-		case Button::DPadRight:
-			return 0x0008;
-		case Button::Plus:
-			return 0x0010;
-		case Button::Minus:
-			return 0x0020;
-		case Button::LStick:
-			return 0x0040;
-		case Button::RStick:
-			return 0x0080;
-		case Button::L:
-			return 0x0100;
-		case Button::R:
-			return 0x0200;
-		case Button::Home:
-			return 0x0400; // Undocumented
 
-		case Button::A:
-			return 0x1000;
-		case Button::B:
-			return 0x2000;
-		case Button::X:
-			return 0x4000;
-		case Button::Y:
-			return 0x8000;
-		default:
-			return 0x0000;
-		}
-	}
+  constexpr unsigned short buttonToReportBitsOld(Button b) {
+    switch (b) {
+    case Button::DPadUp:
+      return 0x0001;
+    case Button::DPadDown:
+      return 0x0002;
+    case Button::DPadLeft:
+      return 0x0004;
+    case Button::DPadRight:
+      return 0x0008;
+    case Button::Plus:
+      return 0x0010;
+    case Button::Minus:
+      return 0x0020;
+    case Button::LStick:
+      return 0x0040;
+    case Button::RStick:
+      return 0x0080;
+    case Button::L:
+      return 0x0100;
+    case Button::R:
+      return 0x0200;
+    case Button::Home:
+      return 0x0400; // Undocumented
 
-	const std::string buttonConfigName{ "bMatchButtonLabels" };
+    case Button::A:
+      return 0x1000;
+    case Button::B:
+      return 0x2000;
+    case Button::X:
+      return 0x4000;
+    case Button::Y:
+      return 0x8000;
+    default:
+      return 0x0000;
+    }
+  }
+
+  const std::string buttonConfigName{ "bMatchButtonLabels" };
 
 	void mapButtonToState(Button b, ExpandedPadState &state) {
 		switch (b) {
@@ -314,30 +236,14 @@ namespace {
 			state.sharePressed = true;
 			return;
 		default:
-			if (Config::get<bool>(buttonConfigName).value_or(false)) {
-				state.xinState.wButtons |= buttonToReportBitsOld(b);
-			}
-			else {
-				state.xinState.wButtons |= buttonToReportBits(b);
-			}
-			return;
+      if (Config::get<bool>(buttonConfigName).value_or(false)) {
+        state.xinState.wButtons |= buttonToReportBitsOld(b);
+      }
+      else {
+        state.xinState.wButtons |= buttonToReportBits(b);
+      }
+      return;
 		}
-	}
-
-	void updateCalibrationRangeStick(const StickPoint &input, StickRange &cal) {
-		using std::max;
-		using std::min;
-
-		cal.x.max = max(cal.x.max, input.x);
-		cal.x.min = min(cal.x.min, input.x);
-		cal.y.max = max(cal.y.max, input.y);
-		cal.y.min = min(cal.y.min, input.y);
-		
-	}
-
-	void updateCalibrationRange(const ExpandedPadState &state, CalibrationData &cal) {
-		updateCalibrationRangeStick(state.leftStick, cal.left);
-		updateCalibrationRangeStick(state.rightStick, cal.right);
 	}
 
 #ifdef _DEBUG
@@ -411,23 +317,31 @@ namespace {
 #endif //#ifdef _DEBUG
 
 	void mapInputToState(const InputPacket &p, CalibrationData &cal, ExpandedPadState &state) {
-		state.leftStick.x = ((p.sticks[1] & 0x0F) << 4) | ((p.sticks[0] & 0xF0) >> 4);
-		state.leftStick.y = p.sticks[2];
-		state.rightStick.x = ((p.sticks[4] & 0x0F) << 4) | ((p.sticks[3] & 0xF0) >> 4);
-		state.rightStick.y = p.sticks[5];
-		
-		updateCalibrationRange(state, cal);
+    auto uint16ToInt16 = [](uint16_t a) {return *(int16_t*)(&a); };
 
+    state.leftStick.x = p.sticks[0] | ((p.sticks[1] & 0xF) << 8);
+    state.leftStick.y = (p.sticks[1] >> 4 | p.sticks[2] << 4);
+    state.rightStick.x = p.sticks[3] | ((p.sticks[4] & 0xF) << 8);
+    state.rightStick.y = (p.sticks[4] >> 4 | p.sticks[5] << 4);
+
+    state.accel.x = uint16ToInt16(p.accel_1[0]) * cal.motionSensor.accelCoeff[0];
+    state.accel.y = uint16ToInt16(p.accel_1[1]) * cal.motionSensor.accelCoeff[1];
+    state.accel.z = uint16ToInt16(p.accel_1[2]) * cal.motionSensor.accelCoeff[2];
+
+    state.gyro.x = uint16ToInt16(p.gyro_1[0]) * cal.motionSensor.gyroCoeff[0];
+    state.gyro.y = uint16ToInt16(p.gyro_1[1]) * cal.motionSensor.gyroCoeff[1];
+    state.gyro.z = uint16ToInt16(p.gyro_1[2]) * cal.motionSensor.gyroCoeff[2];
+		
 		// Sets state.xinState's sticks
 		calibrateToRange(state.leftStick, cal.left, cal.leftCenter, state.xinState.sThumbLX, state.xinState.sThumbLY);
 		calibrateToRange(state.rightStick, cal.right, cal.rightCenter, state.xinState.sThumbRX, state.xinState.sThumbRY);
 
-		vector<tuple<Button, bool>> buttons;
-		pullButtonsFromByte(p.leftButtons, ButtonSource::Left, buttons);
-		pullButtonsFromByte(p.rightButtons, ButtonSource::Right, buttons);
-		pullButtonsFromByte(p.middleButtons, ButtonSource::Middle, buttons);
+		
+		pullButtonsFromByte(p.leftButtons, ButtonSource::Left, state.buttons);
+		pullButtonsFromByte(p.rightButtons, ButtonSource::Right, state.buttons);
+		pullButtonsFromByte(p.middleButtons, ButtonSource::Middle, state.buttons);
 
-		for (auto pair : buttons) {
+		for (auto pair : state.buttons) {
 			if (std::get<1>(pair)) {
 #ifdef _DEBUG
 				std::cout << buttonToString(std::get<0>(pair)) << ' ';
@@ -443,16 +357,164 @@ namespace {
 }; //namespace
 
 namespace Procon {
+  using std::array;
+
+  void SetDefaultCalibration(CalibrationData &dat) {
+    constexpr uchar ucmin = std::numeric_limits<uchar>::min();
+    constexpr uchar ucmax = std::numeric_limits<uchar>::max();
+    dat.leftCenter.x = ucmax / 2;
+    dat.leftCenter.y = ucmax / 2;
+    dat.rightCenter = dat.leftCenter;
+    dat.left.x.min = dat.leftCenter.x;
+    dat.left.x.max = dat.leftCenter.x;
+    dat.left.y = dat.left.x;
+    dat.right = dat.left;
+  }
+
+  void HIDCloser::operator()(hid_device *ptr) {
+    if (ptr != nullptr)
+      hid_close(ptr);
+  }
+  void zeroPadState(ExpandedPadState &state) {
+    for (auto& button : state.buttons)
+    {
+      std::get<1>(button) = false;
+    }
+    state.xinState = { 0 };
+    state.leftStick = { 0 };
+    state.rightStick = { 0 };
+    state.accel = { 0, 0, 0 };
+    state.gyro = { 0, 0, 0 };
+    state.sharePressed = false;
+  }
+
+  Controller::Controller(uchar port) :device(nullptr), port(port) {
+    SetDefaultCalibration(calib);
+  }
+
+  Controller::Controller(Controller &&) = default;
+
+  Controller& Controller::operator=(Controller &&) = default;
+
+  Controller::~Controller() {
+    if (_connected) {
+      XOutputUnPlug(port);
+    }
+    if (device) {
+      static const array<uchar, 2> disconnect{ 0x80, 0x05 };
+      exchange(disconnect);
+    }
+  }
+
+  void Controller::openDevice(hid_device_info *dev) {
+    using namespace std::this_thread;
+    using namespace std::chrono;
+
+    if (dev == nullptr)
+      throw ControllerException("Unable to open controller device: dev was nullptr.");
+    if (dev->product_id != Procon_ID)
+      throw ControllerException("Unable to open controller device: product id was not a Switch Pro Controller.");
+    if (wcscmp(dev->serial_number, L"000000000001") != 0)
+      throw ControllerException("Device is not connected via USB");
+
+    device.reset(hid_open_path(dev->path));
+    if (!device)
+      throw ControllerException("Unable to open controller device: device path could not be opened.");
+
+    // Start handshake
+    if (!exchange(handshake)) {
+      throw ControllerException("Handshake failed.");
+    }
+    exchange(switchBaudrate);
+    exchange(handshake);
+    exchange(HIDOnlyMode);
+
+    //sendSubcommand(0x1, rumbleCommand, enable);
+    // Set report mode to 0x30 (we now get the same data as in the bluetooth case)
+    std::array<uchar, 2> report{ 0x30, 0x00 };
+    sendSubcommand(0x01, 0x03, report);
+    sendSubcommand(0x01, imuDataCommand, enable);
+    sendSubcommand(0x01, ledCommand, led);
+
+    // Read calibration data (use factory calibration for now)
+    readAnalogStickCalibrationData();
+    readMotionSensorCalibrationData();
+
+    if (XOutputPlugIn(port) != ERROR_SUCCESS) {
+      device.reset(nullptr);
+      throw ControllerException("Unable to plugin XOutput controller.");
+    }
+    _connected = true;
+    sleep_for(milliseconds(100));
+    //updateStatus();
+  }
+
+  void Controller::readAnalogStickCalibrationData()
+  {
+    auto factory_stick_cal = getSpiData(0x603D, 0x12).value();
+
+    calib.leftCenter.x = (factory_stick_cal[4] << 8) & 0xF00 | factory_stick_cal[3];
+    calib.leftCenter.y = (factory_stick_cal[5] << 4) | (factory_stick_cal[4] >> 4);
+    calib.left.x.min = calib.leftCenter.x - ((factory_stick_cal[7] << 8) & 0xF00 | factory_stick_cal[6]);
+    calib.left.x.max = calib.leftCenter.x + ((factory_stick_cal[1] << 8) & 0xF00 | factory_stick_cal[0]);
+    calib.left.y.min = calib.leftCenter.y - ((factory_stick_cal[8] << 4) | (factory_stick_cal[7] >> 4));
+    calib.left.y.max = calib.leftCenter.y + ((factory_stick_cal[2] << 4) | (factory_stick_cal[1] >> 4));
+
+    calib.rightCenter.x = (factory_stick_cal[10] << 8) & 0xF00 | factory_stick_cal[9];
+    calib.rightCenter.y = (factory_stick_cal[11] << 4) | (factory_stick_cal[10] >> 4);
+    calib.right.x.min = calib.rightCenter.x - ((factory_stick_cal[13] << 8) & 0xF00 | factory_stick_cal[12]);
+    calib.right.x.max = calib.rightCenter.x + ((factory_stick_cal[16] << 8) & 0xF00 | factory_stick_cal[15]);
+    calib.right.y.min = calib.rightCenter.y - ((factory_stick_cal[14] << 4) | (factory_stick_cal[13] >> 4));
+    calib.right.y.max = calib.rightCenter.y + ((factory_stick_cal[17] << 4) | (factory_stick_cal[16] >> 4));
+  }
+
+  void Controller::readMotionSensorCalibrationData()
+  {
+    auto factory_sensor_cal = getSpiData(0x6020, 0x18).value();
+    auto uint16ToInt16 = [](uint16_t a) {return *(int16_t*)(&a); };
+    array<int16_t, 3> accel_cal
+    {
+      uint16ToInt16(factory_sensor_cal[0x00] | factory_sensor_cal[0x01] << 8),
+      uint16ToInt16(factory_sensor_cal[0x02] | factory_sensor_cal[0x03] << 8),
+      uint16ToInt16(factory_sensor_cal[0x04] | factory_sensor_cal[0x05] << 8)
+    };
+
+    array<int16_t, 3> gyro_cal
+    {
+      uint16ToInt16(factory_sensor_cal[0x0C] | factory_sensor_cal[0x0D] << 8),
+      uint16ToInt16(factory_sensor_cal[0x0E] | factory_sensor_cal[0x0F] << 8),
+      uint16ToInt16(factory_sensor_cal[0x10] | factory_sensor_cal[0x11] << 8)
+    };
+
+    calib.motionSensor.accelCoeff = {
+      (float)(1.0 / (float)(16384 - accel_cal[0])) * 4.0f/*  * 9.8f*/,
+      (float)(1.0 / (float)(16384 - accel_cal[1])) * 4.0f/*  * 9.8f*/,
+      (float)(1.0 / (float)(16384 - accel_cal[2])) * 4.0f/*  * 9.8f*/
+    };
+
+    calib.motionSensor.gyroCoeff = {
+      (float)(936.0 / (float)(13371 - gyro_cal[0])/* * 0.01745329251994*/),
+      (float)(936.0 / (float)(13371 - gyro_cal[1])/* * 0.01745329251994*/),
+      (float)(936.0 / (float)(13371 - gyro_cal[2])/* * 0.01745329251994*/)
+    };
+  }
 
 	void Controller::pollInput() {
 		if (!device)
 			return;
 
-		auto dat = sendCommand(getInput, empty);
-		if (!dat) {
-			throw ControllerException("Error sending getInput command.");
-		}
-		if (dat.value()[0] != 0x30) {
+		//auto dat = sendCommand(getInput, empty);
+    auto dat = receive(200);
+    if (!dat)
+    {
+      return;
+    }
+
+		if  (dat.value()[0] == 0x30 || dat.value()[0] == 0x31 
+      || dat.value()[0] == 0x32 || dat.value()[0] == 0x33)
+    {
+      padStatus.lastStatus = clock::now();
+
 			InputPacket p;
 			memcpy(&p, dat.value().data(), sizeof(InputPacket));
 
@@ -466,7 +528,7 @@ namespace Procon {
 				throw ControllerException(errMsg);
 			}
 		}
-		//updateStatus();
+    //updateStatus();
 	}
 
 	bool Controller::connected() const {
@@ -477,10 +539,6 @@ namespace Procon {
 	}
 	const ExpandedPadState& Controller::getState() const {
 		return padStatus;
-	}
-	void Controller::setCalibrationCenter(const StickPoint &left, const StickPoint &right) {
-		calib.leftCenter = left;
-		calib.rightCenter = right;
 	}
 	void Controller::updateStatus() {
 		if (clock::now() < lastStatus + std::chrono::milliseconds(100)) {
@@ -499,6 +557,16 @@ namespace Procon {
 		sendSubcommand(0x1, ledCommand, ledData);
 		lastStatus = clock::now();
 	}
+
+  Controller::exchangeArray Controller::receive(int timeout)
+  {
+    std::array<uchar, exchangeLen> ret;
+    ret.fill(0);
+    int retLen = hid_read_timeout(device.get(), ret.data(), exchangeLen, timeout);
+    if (retLen == 0)
+      return {};
+    return ret;
+  }
 
 	Controller::exchangeArray Controller::sendRumble(uchar largeMotor, uchar smallMotor){
 		std::array<uchar, 9> buf{
@@ -522,6 +590,28 @@ namespace Procon {
 		}
 		return sendCommand(0x10, buf);
 	}
+
+  Controller::exchangeArray Controller::getSpiData(uint32_t offset, const uint8_t readLen)
+  {
+    std::array<uint8_t, 0x100> buf;
+    while (true)
+    {
+      buf.fill(0);
+      *(uint32_t*)(buf.data()) = offset;
+      *(uint8_t*)(buf.data() + 4) = readLen;
+      auto res = sendSubcommand(0x01, 0x10, buf);
+      //if (res && (*(uint16_t*)(res.value().data() + 0xD) == 0x1090) && (*(uint32_t*)(res.value().data() + 0xF) == offset)) // For bluetooth
+      if (res && (*(uint16_t*)(res.value().data() + 0x17) == 0x1090) && (*(uint32_t*)(res.value().data() + 0x19) == offset))
+      {
+        std::array<uchar, exchangeLen> ret;
+        ret.fill(0);
+        //memcpy(ret.data(), res.value().data() + 0x14, readLen); // For bluetooth
+        memcpy(ret.data(), res.value().data() + 0x1E, readLen);
+        return ret;
+      }
+    }
+    return {};
+  }
 
 	ControllerException::ControllerException(const std::string& what) : runtime_error(what) {}
 	ControllerException::ControllerException(const char* what) : runtime_error(what) {}

--- a/Controller.hpp
+++ b/Controller.hpp
@@ -7,6 +7,7 @@
 #include <thread>
 #include <vector>
 #include <array>
+#include <map>
 
 #ifndef NOMINMAX
 #define NOMINMAX
@@ -69,7 +70,7 @@ namespace Procon {
 
 	struct ExpandedPadState {
 		XINPUT_GAMEPAD xinState;
-		std::vector<std::tuple<Button, bool>> buttons;
+		std::map<Button, bool> buttons;
 		StickPoint leftStick;
 		StickPoint rightStick;
 		AccelData accel;

--- a/Controller.hpp
+++ b/Controller.hpp
@@ -21,66 +21,66 @@ namespace Procon {
 
 	constexpr size_t exchangeLen{ 0x400 };
 
-  struct AccelData {
-    float x;
-    float y;
-    float z;
-  };
-
-  struct GyroData {
-    float x;
-    float y;
-    float z;
-  };
-
-  struct AxisRange {
-		uint16_t min;
-    uint16_t max;
+	struct AccelData {
+		float x;
+		float y;
+		float z;
 	};
-	
-  struct StickRange {
+
+	struct GyroData {
+		float x;
+		float y;
+		float z;
+	};
+
+	struct AxisRange {
+		uint16_t min;
+		uint16_t max;
+	};
+
+	struct StickRange {
 		AxisRange x;
 		AxisRange y;
 	};
-	
-  struct StickPoint {
-    uint16_t x;
-    uint16_t y;
+
+	struct StickPoint {
+		uint16_t x;
+		uint16_t y;
 	};
 
-  struct SensorCalibration {
-    std::array<float, 3> accelCoeff;
-    std::array<float, 3> gyroCoeff;
-  };
-	
-  struct CalibrationData {
+	struct SensorCalibration {
+		std::array<float, 3> accelCoeff;
+		std::array<float, 3> gyroCoeff;
+	};
+
+	struct CalibrationData {
 		StickRange left;
 		StickRange right;
 		StickPoint leftCenter;
 		StickPoint rightCenter;
-    SensorCalibration motionSensor;
+		SensorCalibration motionSensor;
 	};
 
 	void SetDefaultCalibration(CalibrationData &dat);
-	
-  struct HIDCloser {
+
+	struct HIDCloser {
 		void operator()(hid_device *ptr);
 	};
-	
-  struct ExpandedPadState {
+
+	struct ExpandedPadState {
 		XINPUT_GAMEPAD xinState;
-    std::vector<std::tuple<Button, bool>> buttons;
+		std::vector<std::tuple<Button, bool>> buttons;
 		StickPoint leftStick;
 		StickPoint rightStick;
-    AccelData accel;
-    GyroData gyro;
-    std::chrono::steady_clock::time_point lastStatus;
+		AccelData accel;
+		GyroData gyro;
+		std::chrono::steady_clock::time_point lastStatus;
 		bool sharePressed;
 	};
-	
-  void zeroPadState(ExpandedPadState &state);
-	
-  // Switch Procon class.
+
+	void zeroPadState(ExpandedPadState &state);
+
+	// Switch Procon class.
 	// Create, then call openDevice(hid_device_info) to initialize.
 	// Call pollInput() to send input to ViGEm, such as in a main loop.
 	// Cleanup is automatic when the object is destroyed.
@@ -90,7 +90,7 @@ namespace Procon {
 		std::unique_ptr<hid_device, HIDCloser> device;
 		uchar rumbleCounter{ 0 };
 		using clock = std::chrono::steady_clock;
-    clock::time_point lastStatus;
+		clock::time_point lastStatus;
 		uchar port{ 0 };
 		ExpandedPadState padStatus{};
 		CalibrationData calib;
@@ -111,12 +111,12 @@ namespace Procon {
 	private:
 
 		void updateStatus();
-    void readAnalogStickCalibrationData();
-    void readMotionSensorCalibrationData();
-		
+		void readAnalogStickCalibrationData();
+		void readMotionSensorCalibrationData();
+
 		using exchangeArray = std::optional<std::array<uchar, exchangeLen>>;
 
-    exchangeArray receive(int timeout);
+		exchangeArray receive(int timeout);
 
 		template<size_t len>
 		exchangeArray exchange(std::array<uchar, len> const &data) {
@@ -149,9 +149,9 @@ namespace Procon {
 		template<size_t len>
 		exchangeArray sendSubcommand(uchar command, uchar subcommand, std::array<uchar, len> const& data) {
 			std::array<uchar, 10 + len> buf
-			{ 
+			{
 				static_cast<uchar>(rumbleCounter++ & 0xF),
-        // For command 0x01 this is the rumble data
+				// For command 0x01 this is the rumble data
 				0x00_uc,
 				0x01_uc,
 				0x40_uc,
@@ -160,8 +160,8 @@ namespace Procon {
 				0x01_uc,
 				0x40_uc,
 				0x40_uc,
-        // Rumble data end
-        // Now comes the additional subcommand if using 0x01 instead of 0x10 for rumble data
+				// Rumble data end
+				// Now comes the additional subcommand if using 0x01 instead of 0x10 for rumble data
 				subcommand
 			};
 			if (len > 0) {
@@ -170,7 +170,7 @@ namespace Procon {
 			return sendCommand(command, buf);
 		}
 
-    exchangeArray getSpiData(uint32_t offset, const uint8_t readLen);
+		exchangeArray getSpiData(uint32_t offset, const uint8_t readLen);
 		exchangeArray sendRumble(uchar largeMotor, uchar smallMotor);
 	};
 

--- a/Licenses/LICENSE-CRC.txt
+++ b/Licenses/LICENSE-CRC.txt
@@ -1,0 +1,28 @@
+CRC++
+Copyright (c) 2016, Daniel Bahr
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of CRC++ nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ProconXInput.sln
+++ b/ProconXInput.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2010
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ProconXInput", "ProconXInput.vcxproj", "{29E8D818-8BA7-4539-8914-121DB9E03B71}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{29E8D818-8BA7-4539-8914-121DB9E03B71}.Debug|x64.ActiveCfg = Debug|x64
+		{29E8D818-8BA7-4539-8914-121DB9E03B71}.Debug|x64.Build.0 = Debug|x64
+		{29E8D818-8BA7-4539-8914-121DB9E03B71}.Debug|x86.ActiveCfg = Debug|Win32
+		{29E8D818-8BA7-4539-8914-121DB9E03B71}.Debug|x86.Build.0 = Debug|Win32
+		{29E8D818-8BA7-4539-8914-121DB9E03B71}.Release|x64.ActiveCfg = Release|x64
+		{29E8D818-8BA7-4539-8914-121DB9E03B71}.Release|x64.Build.0 = Release|x64
+		{29E8D818-8BA7-4539-8914-121DB9E03B71}.Release|x86.ActiveCfg = Release|Win32
+		{29E8D818-8BA7-4539-8914-121DB9E03B71}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BC2471EC-75B6-48D1-936E-A6836708D62C}
+	EndGlobalSection
+EndGlobal

--- a/ProconXInput.vcxproj
+++ b/ProconXInput.vcxproj
@@ -22,7 +22,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{29E8D818-8BA7-4539-8914-121DB9E03B71}</ProjectGuid>
     <RootNamespace>ProconXInput</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -131,6 +131,7 @@
     <ClCompile Include="Controller.cpp" />
     <ClCompile Include="hid.c" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="UdpServer.cpp" />
     <ClCompile Include="Version.cpp" />
     <ClCompile Include="XOutput.cpp" />
   </ItemGroup>
@@ -139,7 +140,9 @@
     <ClInclude Include="Common.hpp" />
     <ClInclude Include="Config.hpp" />
     <ClInclude Include="Controller.hpp" />
+    <ClInclude Include="CRC.h" />
     <ClInclude Include="hidapi.h" />
+    <ClInclude Include="UdpServer.h" />
     <ClInclude Include="Version.hpp" />
     <ClInclude Include="XOutput.hpp" />
   </ItemGroup>

--- a/ProconXInput.vcxproj.filters
+++ b/ProconXInput.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClCompile Include="Config.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="UdpServer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common.hpp">
@@ -57,6 +60,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Config.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UdpServer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CRC.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/UdpServer.cpp
+++ b/UdpServer.cpp
@@ -1,0 +1,269 @@
+#include <stdexcept>
+#include <intrin.h>
+
+#include <chrono>
+
+#include "CRC.h"
+#include "UdpServer.h"
+
+#pragma comment(lib, "Ws2_32.lib")
+
+UdpServer::UdpServer()
+{
+  WSADATA w;
+  if (WSAStartup(0x0101, &w) != 0)
+  {
+    throw std::runtime_error("Could not open Windows connection");
+  }
+
+  socket_ = socket(AF_INET, SOCK_DGRAM, 0);
+  if (socket_ == INVALID_SOCKET)
+  {
+    WSACleanup();
+    throw std::runtime_error("Could not create socket");
+  }
+  //u_long iMode = 1;
+  //ioctlsocket(socket_, FIONBIO, &iMode);
+
+  addr_.sin_family = AF_INET;
+  addr_.sin_port = htons(26760);
+  addr_.sin_addr.S_un.S_un_b.s_b1 = 127;
+  addr_.sin_addr.S_un.S_un_b.s_b2 = 0;
+  addr_.sin_addr.S_un.S_un_b.s_b3 = 0;
+  addr_.sin_addr.S_un.S_un_b.s_b4 = 1;
+
+  if (bind(socket_, (SOCKADDR*)&addr_, sizeof(SOCKADDR_IN)))
+  {
+    closesocket(socket_);
+    WSACleanup();
+    throw std::runtime_error("Could not bind name to socket");
+  } 
+
+  serverId_ = 1337;
+
+  packetCounter_ = 0;
+
+  gamePad_.PadState = DsState::CONNECTED;
+  gamePad_.Model = DsModel::DS4;
+  gamePad_.ConnectionType = DsConnection::USB;
+  gamePad_.PadMacAddress.byte1 = 0;
+  gamePad_.PadMacAddress.byte2 = 0;
+  gamePad_.PadMacAddress.byte3 = 1;
+  gamePad_.BatteryStatus = DsBattery::HIGH;
+  gamePad_.IsActive = 0;
+
+  gamePadNone_.PadState = DsState::DISCONNECTED;
+  gamePadNone_.Model = DsModel::NONE;
+  gamePadNone_.ConnectionType = DsConnection::NONE;
+  gamePadNone_.PadMacAddress.byte1 = 0;
+  gamePadNone_.PadMacAddress.byte2 = 0;
+  gamePadNone_.PadMacAddress.byte3 = 0;
+  gamePadNone_.BatteryStatus = DsBattery::NONE;
+  gamePadNone_.IsActive = 0;
+}
+
+void UdpServer::receive()
+{
+  memset(buffer_, 0, BufferLength);
+  int slen = sizeof(SOCKADDR_IN);
+
+  unsigned long l;
+  ioctlsocket(socket_, FIONREAD, &l);
+  if (l > 0)
+  {
+    int ret = recvfrom(socket_, buffer_, BufferLength, 0, (SOCKADDR*)&remoteAddr_, &slen);
+    if (ret == SOCKET_ERROR)
+    {
+      throw std::runtime_error("Stuff");
+    }
+
+    processIncoming(ret);
+  }
+}
+
+void UdpServer::newReportIncoming(const Procon::ExpandedPadState& state)
+{
+  for (auto& client : clients_)
+  {
+    std::vector<char> outData(100);
+    int outIdx = beginPacket(outData, eMessageType::DSUS_PadDataRsp, 1001);
+
+    ProtocolPacket* packet = (ProtocolPacket*)(outData.data());
+
+    packet->Metadata = gamePad_;
+    packet->Metadata.IsActive = 1;
+    packet->PacketCounter = packetCounter_++;
+
+    packet->LeftKeys = 0x00;
+    packet->RightKeys = 0x00;
+    packet->PS = 0x00;
+    packet->TouchButton = 0x00;
+    packet->LeftStick = 0x0000;
+    packet->RightStick = 0x0000;
+    packet->DpadLeft = 0x00;
+    packet->DpadDown = 0x00;
+    packet->DpadRight = 0x00;
+    packet->DpadUp = 0x00;
+    packet->KeyY = 0x00;
+    packet->KeyB = 0x00;
+    packet->KeyA = 0x00;
+    packet->KeyX = 0x00;
+    packet->KeyR = 0x00;
+    packet->KeyL = 0x00;
+    packet->KeyZR = 0x00;
+    packet->KeyZL = 0x00;
+    packet->TPad0.IsActive = 0;
+    packet->TPad0.Id = 0;
+    packet->TPad0.X = 0x0000;
+    packet->TPad0.Y = 0x0000;
+    packet->TPad1.IsActive = 0;
+    packet->TPad1.Id = 1;
+    packet->TPad1.X = 0x0000;
+    packet->TPad1.Y = 0x0000;
+    packet->MotionTimestamp = state.lastStatus.time_since_epoch().count() / 1000;
+
+    float tmpAZ = -state.accel.z;
+    packet->AccelX = *(uint32_t*)(&state.accel.y);
+    packet->AccelY = *(uint32_t*)(&tmpAZ);
+    packet->AccelZ = *(uint32_t*)(&state.accel.x);
+
+    float tmpGX = state.gyro.x;
+    float tmpGY = -state.gyro.y;
+    float tmpGZ = -state.gyro.z;
+    packet->GyroPitch = *(uint32_t*)(&tmpGY); // y
+    packet->GyroYaw = *(uint32_t*)(&tmpGZ); // -z
+    packet->GyroRoll = *(uint32_t*)(&tmpGX); // x
+
+    finishPacket(outData);
+
+    if (sendto(socket_, outData.data(), (uint32_t)outData.size(), 0, (SOCKADDR*)&client, sizeof(SOCKADDR_IN)) == SOCKET_ERROR)
+    {
+      throw std::runtime_error("Something went wrong");
+    }
+  }
+}
+
+void UdpServer::processIncoming(int recv_len)
+{
+  int currIdx = 0;
+  if (buffer_[0] != 'D' || buffer_[1] != 'S' || buffer_[2] != 'U' || buffer_[3] != 'C')
+    return;
+  else
+    currIdx += 4;
+
+  uint16_t protocolVersion = *(uint16_t*)(buffer_ + currIdx);
+  currIdx += 2;
+  uint16_t packetSize = *(uint16_t*)(buffer_ + currIdx);
+  currIdx += 2;
+  uint32_t crcValue = *(uint32_t*)(buffer_ + currIdx);
+  *(uint32_t*)(buffer_ + currIdx) = 0;
+  uint32_t expectedCrc = CRC::Calculate(buffer_, recv_len, CRC::CRC_32());
+  currIdx += 4;
+  uint32_t clientId = *(uint32_t*)(buffer_ + currIdx);
+  currIdx += 4;
+  eMessageType messageType = *(eMessageType*)(buffer_ + currIdx);
+  currIdx += 4;
+
+  if (messageType == eMessageType::DSUC_VersionReq)
+  {
+    std::vector<char> outData(4);
+    int outIdx = 0;
+    // Is inside the header now
+    //*(uint32_t*)(outData.data() + outIdx) = (uint32_t)eMessageType::DSUS_VersionRsp;
+    //outIdx += 4;
+
+    *(uint16_t*)(outData.data() + outIdx) = MaxProtocolVersion;
+    outIdx += 2;
+    outData[++outIdx] = 0;
+    outData[++outIdx] = 0;
+
+    sendPacket(outData, eMessageType::DSUS_VersionRsp, 1001);
+  }
+  else if (messageType == eMessageType::DSUC_ListPorts)
+  {
+    int32_t numPadRequests = *(int32_t*)(buffer_ + currIdx);
+    currIdx += 4;
+
+    int requestsIdx = currIdx;
+    for (int i = 0; i < numPadRequests; ++i)
+    {
+      uint8_t currRequest = buffer_[requestsIdx + i];
+    }
+
+    std::vector<char> outData(12);
+    for (int i = 0; i < numPadRequests; ++i)
+    {
+      uint8_t currRequest = buffer_[requestsIdx + i];
+      
+      int outIdx = 0;
+      // Is inside the header now
+      //*(uint32_t*)(outData.data() + outIdx) = (uint32_t)eMessageType::DSUS_PortInfo;
+      //outIdx += 4;
+
+      GamePadMeta* gamePad = (GamePadMeta*)(outData.data() + outIdx);
+      if (i == 0)
+      {
+        *gamePad = gamePad_;
+      }
+      else
+      {
+        *gamePad = gamePadNone_;
+      }
+      gamePad->PadId = i;
+
+      sendPacket(outData, eMessageType::DSUS_PortInfo, 1001);
+    }
+  }
+  else if (messageType == eMessageType::DSUC_PadDataReq)
+  {
+    uint8_t regFlags = *(uint8_t*)(buffer_ + currIdx);
+    currIdx += 1;
+    uint8_t idToReg = *(uint8_t*)(buffer_ + currIdx);
+    currIdx += 1;
+    PhysicalAddress macToReg = *(PhysicalAddress*)(buffer_ + currIdx);
+    currIdx += 6;
+
+    //if (std::find(clients_.begin(), clients_.end(), remoteAddr_) == clients_.end())
+    //{
+    //  clients_.push_back(remoteAddr_);
+    //}
+    clients_[remoteAddr_] = macToReg;
+  }
+}
+
+int UdpServer::beginPacket(std::vector<char>& packetData, UdpServer::eMessageType messageType, uint16_t reqProtocolVersion)
+{
+  PacketHeader* packetHeader = (PacketHeader*)(packetData.data());
+  packetHeader->Header[0] = 'D';
+  packetHeader->Header[1] = 'S';
+  packetHeader->Header[2] = 'U';
+  packetHeader->Header[3] = 'S';
+  packetHeader->Version = reqProtocolVersion;
+  packetHeader->Length = (uint16_t)(packetData.size() - 16);
+  packetHeader->Crc32 = 0;
+  packetHeader->ServerId = serverId_;
+  packetHeader->MessageType = (uint32_t)messageType;
+
+  return sizeof(PacketHeader);
+}
+
+void UdpServer::finishPacket(std::vector<char>& packetData)
+{
+  uint32_t crc32 = CRC::Calculate(packetData.data(), packetData.size(), CRC::CRC_32());
+  PacketHeader* packetHeader = (PacketHeader*)(packetData.data());
+  packetHeader->Crc32 = crc32;
+}
+
+void UdpServer::sendPacket(std::vector<char>& buffer, UdpServer::eMessageType messageType, uint16_t reqProtocolVersion)
+{
+  packetData_.resize(buffer.size() + sizeof(PacketHeader));
+  memset(packetData_.data(), 0, buffer.size() + sizeof(PacketHeader));
+  int curIdx = beginPacket(packetData_, messageType, reqProtocolVersion);
+  memcpy(packetData_.data() + curIdx, buffer.data(), buffer.size());
+  finishPacket(packetData_);
+
+  if (sendto(socket_, packetData_.data(), (uint32_t)packetData_.size(), 0, (SOCKADDR*)&remoteAddr_, sizeof(SOCKADDR_IN)) == SOCKET_ERROR)
+  {
+    throw std::runtime_error("Something went wrong");
+  }
+}

--- a/UdpServer.cpp
+++ b/UdpServer.cpp
@@ -10,260 +10,260 @@
 
 UdpServer::UdpServer()
 {
-  WSADATA w;
-  if (WSAStartup(0x0101, &w) != 0)
-  {
-    throw std::runtime_error("Could not open Windows connection");
-  }
+	WSADATA w;
+	if (WSAStartup(0x0101, &w) != 0)
+	{
+		throw std::runtime_error("Could not open Windows connection");
+	}
 
-  socket_ = socket(AF_INET, SOCK_DGRAM, 0);
-  if (socket_ == INVALID_SOCKET)
-  {
-    WSACleanup();
-    throw std::runtime_error("Could not create socket");
-  }
-  //u_long iMode = 1;
-  //ioctlsocket(socket_, FIONBIO, &iMode);
+	socket_ = socket(AF_INET, SOCK_DGRAM, 0);
+	if (socket_ == INVALID_SOCKET)
+	{
+		WSACleanup();
+		throw std::runtime_error("Could not create socket");
+	}
+	//u_long iMode = 1;
+	//ioctlsocket(socket_, FIONBIO, &iMode);
 
-  addr_.sin_family = AF_INET;
-  addr_.sin_port = htons(26760);
-  addr_.sin_addr.S_un.S_un_b.s_b1 = 127;
-  addr_.sin_addr.S_un.S_un_b.s_b2 = 0;
-  addr_.sin_addr.S_un.S_un_b.s_b3 = 0;
-  addr_.sin_addr.S_un.S_un_b.s_b4 = 1;
+	addr_.sin_family = AF_INET;
+	addr_.sin_port = htons(26760);
+	addr_.sin_addr.S_un.S_un_b.s_b1 = 127;
+	addr_.sin_addr.S_un.S_un_b.s_b2 = 0;
+	addr_.sin_addr.S_un.S_un_b.s_b3 = 0;
+	addr_.sin_addr.S_un.S_un_b.s_b4 = 1;
 
-  if (bind(socket_, (SOCKADDR*)&addr_, sizeof(SOCKADDR_IN)))
-  {
-    closesocket(socket_);
-    WSACleanup();
-    throw std::runtime_error("Could not bind name to socket");
-  } 
+	if (bind(socket_, (SOCKADDR*)&addr_, sizeof(SOCKADDR_IN)))
+	{
+		closesocket(socket_);
+		WSACleanup();
+		throw std::runtime_error("Could not bind name to socket");
+	}
 
-  serverId_ = 1337;
+	serverId_ = 1337;
 
-  packetCounter_ = 0;
+	packetCounter_ = 0;
 
-  gamePad_.PadState = DsState::CONNECTED;
-  gamePad_.Model = DsModel::DS4;
-  gamePad_.ConnectionType = DsConnection::USB;
-  gamePad_.PadMacAddress.byte1 = 0;
-  gamePad_.PadMacAddress.byte2 = 0;
-  gamePad_.PadMacAddress.byte3 = 1;
-  gamePad_.BatteryStatus = DsBattery::HIGH;
-  gamePad_.IsActive = 0;
+	gamePad_.PadState = DsState::CONNECTED;
+	gamePad_.Model = DsModel::DS4;
+	gamePad_.ConnectionType = DsConnection::USB;
+	gamePad_.PadMacAddress.byte1 = 0;
+	gamePad_.PadMacAddress.byte2 = 0;
+	gamePad_.PadMacAddress.byte3 = 1;
+	gamePad_.BatteryStatus = DsBattery::HIGH;
+	gamePad_.IsActive = 0;
 
-  gamePadNone_.PadState = DsState::DISCONNECTED;
-  gamePadNone_.Model = DsModel::NONE;
-  gamePadNone_.ConnectionType = DsConnection::NONE;
-  gamePadNone_.PadMacAddress.byte1 = 0;
-  gamePadNone_.PadMacAddress.byte2 = 0;
-  gamePadNone_.PadMacAddress.byte3 = 0;
-  gamePadNone_.BatteryStatus = DsBattery::NONE;
-  gamePadNone_.IsActive = 0;
+	gamePadNone_.PadState = DsState::DISCONNECTED;
+	gamePadNone_.Model = DsModel::NONE;
+	gamePadNone_.ConnectionType = DsConnection::NONE;
+	gamePadNone_.PadMacAddress.byte1 = 0;
+	gamePadNone_.PadMacAddress.byte2 = 0;
+	gamePadNone_.PadMacAddress.byte3 = 0;
+	gamePadNone_.BatteryStatus = DsBattery::NONE;
+	gamePadNone_.IsActive = 0;
 }
 
 void UdpServer::receive()
 {
-  memset(buffer_, 0, BufferLength);
-  int slen = sizeof(SOCKADDR_IN);
+	memset(buffer_, 0, BufferLength);
+	int slen = sizeof(SOCKADDR_IN);
 
-  unsigned long l;
-  ioctlsocket(socket_, FIONREAD, &l);
-  if (l > 0)
-  {
-    int ret = recvfrom(socket_, buffer_, BufferLength, 0, (SOCKADDR*)&remoteAddr_, &slen);
-    if (ret == SOCKET_ERROR)
-    {
-      throw std::runtime_error("Stuff");
-    }
+	unsigned long l;
+	ioctlsocket(socket_, FIONREAD, &l);
+	if (l > 0)
+	{
+		int ret = recvfrom(socket_, buffer_, BufferLength, 0, (SOCKADDR*)&remoteAddr_, &slen);
+		if (ret == SOCKET_ERROR)
+		{
+			throw std::runtime_error("Stuff");
+		}
 
-    processIncoming(ret);
-  }
+		processIncoming(ret);
+	}
 }
 
 void UdpServer::newReportIncoming(const Procon::ExpandedPadState& state)
 {
-  for (auto& client : clients_)
-  {
-    std::vector<char> outData(100);
-    int outIdx = beginPacket(outData, eMessageType::DSUS_PadDataRsp, 1001);
+	for (auto& client : clients_)
+	{
+		std::vector<char> outData(100);
+		int outIdx = beginPacket(outData, eMessageType::DSUS_PadDataRsp, 1001);
 
-    ProtocolPacket* packet = (ProtocolPacket*)(outData.data());
+		ProtocolPacket* packet = (ProtocolPacket*)(outData.data());
 
-    packet->Metadata = gamePad_;
-    packet->Metadata.IsActive = 1;
-    packet->PacketCounter = packetCounter_++;
+		packet->Metadata = gamePad_;
+		packet->Metadata.IsActive = 1;
+		packet->PacketCounter = packetCounter_++;
 
-    packet->LeftKeys = 0x00;
-    packet->RightKeys = 0x00;
-    packet->PS = 0x00;
-    packet->TouchButton = 0x00;
-    packet->LeftStick = 0x0000;
-    packet->RightStick = 0x0000;
-    packet->DpadLeft = 0x00;
-    packet->DpadDown = 0x00;
-    packet->DpadRight = 0x00;
-    packet->DpadUp = 0x00;
-    packet->KeyY = 0x00;
-    packet->KeyB = 0x00;
-    packet->KeyA = 0x00;
-    packet->KeyX = 0x00;
-    packet->KeyR = 0x00;
-    packet->KeyL = 0x00;
-    packet->KeyZR = 0x00;
-    packet->KeyZL = 0x00;
-    packet->TPad0.IsActive = 0;
-    packet->TPad0.Id = 0;
-    packet->TPad0.X = 0x0000;
-    packet->TPad0.Y = 0x0000;
-    packet->TPad1.IsActive = 0;
-    packet->TPad1.Id = 1;
-    packet->TPad1.X = 0x0000;
-    packet->TPad1.Y = 0x0000;
-    packet->MotionTimestamp = state.lastStatus.time_since_epoch().count() / 1000;
+		packet->LeftKeys = 0x00;
+		packet->RightKeys = 0x00;
+		packet->PS = 0x00;
+		packet->TouchButton = 0x00;
+		packet->LeftStick = 0x0000;
+		packet->RightStick = 0x0000;
+		packet->DpadLeft = 0x00;
+		packet->DpadDown = 0x00;
+		packet->DpadRight = 0x00;
+		packet->DpadUp = 0x00;
+		packet->KeyY = 0x00;
+		packet->KeyB = 0x00;
+		packet->KeyA = 0x00;
+		packet->KeyX = 0x00;
+		packet->KeyR = 0x00;
+		packet->KeyL = 0x00;
+		packet->KeyZR = 0x00;
+		packet->KeyZL = 0x00;
+		packet->TPad0.IsActive = 0;
+		packet->TPad0.Id = 0;
+		packet->TPad0.X = 0x0000;
+		packet->TPad0.Y = 0x0000;
+		packet->TPad1.IsActive = 0;
+		packet->TPad1.Id = 1;
+		packet->TPad1.X = 0x0000;
+		packet->TPad1.Y = 0x0000;
+		packet->MotionTimestamp = state.lastStatus.time_since_epoch().count() / 1000;
 
-    float tmpAZ = -state.accel.z;
-    packet->AccelX = *(uint32_t*)(&state.accel.y);
-    packet->AccelY = *(uint32_t*)(&tmpAZ);
-    packet->AccelZ = *(uint32_t*)(&state.accel.x);
+		float tmpAZ = -state.accel.z;
+		packet->AccelX = *(uint32_t*)(&state.accel.y);
+		packet->AccelY = *(uint32_t*)(&tmpAZ);
+		packet->AccelZ = *(uint32_t*)(&state.accel.x);
 
-    float tmpGX = state.gyro.x;
-    float tmpGY = -state.gyro.y;
-    float tmpGZ = -state.gyro.z;
-    packet->GyroPitch = *(uint32_t*)(&tmpGY); // y
-    packet->GyroYaw = *(uint32_t*)(&tmpGZ); // -z
-    packet->GyroRoll = *(uint32_t*)(&tmpGX); // x
+		float tmpGX = state.gyro.x;
+		float tmpGY = -state.gyro.y;
+		float tmpGZ = -state.gyro.z;
+		packet->GyroPitch = *(uint32_t*)(&tmpGY); // y
+		packet->GyroYaw = *(uint32_t*)(&tmpGZ); // -z
+		packet->GyroRoll = *(uint32_t*)(&tmpGX); // x
 
-    finishPacket(outData);
+		finishPacket(outData);
 
-    if (sendto(socket_, outData.data(), (uint32_t)outData.size(), 0, (SOCKADDR*)&client, sizeof(SOCKADDR_IN)) == SOCKET_ERROR)
-    {
-      throw std::runtime_error("Something went wrong");
-    }
-  }
+		if (sendto(socket_, outData.data(), (uint32_t)outData.size(), 0, (SOCKADDR*)&client, sizeof(SOCKADDR_IN)) == SOCKET_ERROR)
+		{
+			throw std::runtime_error("Something went wrong");
+		}
+	}
 }
 
 void UdpServer::processIncoming(int recv_len)
 {
-  int currIdx = 0;
-  if (buffer_[0] != 'D' || buffer_[1] != 'S' || buffer_[2] != 'U' || buffer_[3] != 'C')
-    return;
-  else
-    currIdx += 4;
+	int currIdx = 0;
+	if (buffer_[0] != 'D' || buffer_[1] != 'S' || buffer_[2] != 'U' || buffer_[3] != 'C')
+		return;
+	else
+		currIdx += 4;
 
-  uint16_t protocolVersion = *(uint16_t*)(buffer_ + currIdx);
-  currIdx += 2;
-  uint16_t packetSize = *(uint16_t*)(buffer_ + currIdx);
-  currIdx += 2;
-  uint32_t crcValue = *(uint32_t*)(buffer_ + currIdx);
-  *(uint32_t*)(buffer_ + currIdx) = 0;
-  uint32_t expectedCrc = CRC::Calculate(buffer_, recv_len, CRC::CRC_32());
-  currIdx += 4;
-  uint32_t clientId = *(uint32_t*)(buffer_ + currIdx);
-  currIdx += 4;
-  eMessageType messageType = *(eMessageType*)(buffer_ + currIdx);
-  currIdx += 4;
+	uint16_t protocolVersion = *(uint16_t*)(buffer_ + currIdx);
+	currIdx += 2;
+	uint16_t packetSize = *(uint16_t*)(buffer_ + currIdx);
+	currIdx += 2;
+	uint32_t crcValue = *(uint32_t*)(buffer_ + currIdx);
+	*(uint32_t*)(buffer_ + currIdx) = 0;
+	uint32_t expectedCrc = CRC::Calculate(buffer_, recv_len, CRC::CRC_32());
+	currIdx += 4;
+	uint32_t clientId = *(uint32_t*)(buffer_ + currIdx);
+	currIdx += 4;
+	eMessageType messageType = *(eMessageType*)(buffer_ + currIdx);
+	currIdx += 4;
 
-  if (messageType == eMessageType::DSUC_VersionReq)
-  {
-    std::vector<char> outData(4);
-    int outIdx = 0;
-    // Is inside the header now
-    //*(uint32_t*)(outData.data() + outIdx) = (uint32_t)eMessageType::DSUS_VersionRsp;
-    //outIdx += 4;
+	if (messageType == eMessageType::DSUC_VersionReq)
+	{
+		std::vector<char> outData(4);
+		int outIdx = 0;
+		// Is inside the header now
+		//*(uint32_t*)(outData.data() + outIdx) = (uint32_t)eMessageType::DSUS_VersionRsp;
+		//outIdx += 4;
 
-    *(uint16_t*)(outData.data() + outIdx) = MaxProtocolVersion;
-    outIdx += 2;
-    outData[++outIdx] = 0;
-    outData[++outIdx] = 0;
+		*(uint16_t*)(outData.data() + outIdx) = MaxProtocolVersion;
+		outIdx += 2;
+		outData[++outIdx] = 0;
+		outData[++outIdx] = 0;
 
-    sendPacket(outData, eMessageType::DSUS_VersionRsp, 1001);
-  }
-  else if (messageType == eMessageType::DSUC_ListPorts)
-  {
-    int32_t numPadRequests = *(int32_t*)(buffer_ + currIdx);
-    currIdx += 4;
+		sendPacket(outData, eMessageType::DSUS_VersionRsp, 1001);
+	}
+	else if (messageType == eMessageType::DSUC_ListPorts)
+	{
+		int32_t numPadRequests = *(int32_t*)(buffer_ + currIdx);
+		currIdx += 4;
 
-    int requestsIdx = currIdx;
-    for (int i = 0; i < numPadRequests; ++i)
-    {
-      uint8_t currRequest = buffer_[requestsIdx + i];
-    }
+		int requestsIdx = currIdx;
+		for (int i = 0; i < numPadRequests; ++i)
+		{
+			uint8_t currRequest = buffer_[requestsIdx + i];
+		}
 
-    std::vector<char> outData(12);
-    for (int i = 0; i < numPadRequests; ++i)
-    {
-      uint8_t currRequest = buffer_[requestsIdx + i];
-      
-      int outIdx = 0;
-      // Is inside the header now
-      //*(uint32_t*)(outData.data() + outIdx) = (uint32_t)eMessageType::DSUS_PortInfo;
-      //outIdx += 4;
+		std::vector<char> outData(12);
+		for (int i = 0; i < numPadRequests; ++i)
+		{
+			uint8_t currRequest = buffer_[requestsIdx + i];
 
-      GamePadMeta* gamePad = (GamePadMeta*)(outData.data() + outIdx);
-      if (i == 0)
-      {
-        *gamePad = gamePad_;
-      }
-      else
-      {
-        *gamePad = gamePadNone_;
-      }
-      gamePad->PadId = i;
+			int outIdx = 0;
+			// Is inside the header now
+			//*(uint32_t*)(outData.data() + outIdx) = (uint32_t)eMessageType::DSUS_PortInfo;
+			//outIdx += 4;
 
-      sendPacket(outData, eMessageType::DSUS_PortInfo, 1001);
-    }
-  }
-  else if (messageType == eMessageType::DSUC_PadDataReq)
-  {
-    uint8_t regFlags = *(uint8_t*)(buffer_ + currIdx);
-    currIdx += 1;
-    uint8_t idToReg = *(uint8_t*)(buffer_ + currIdx);
-    currIdx += 1;
-    PhysicalAddress macToReg = *(PhysicalAddress*)(buffer_ + currIdx);
-    currIdx += 6;
+			GamePadMeta* gamePad = (GamePadMeta*)(outData.data() + outIdx);
+			if (i == 0)
+			{
+				*gamePad = gamePad_;
+			}
+			else
+			{
+				*gamePad = gamePadNone_;
+			}
+			gamePad->PadId = i;
 
-    //if (std::find(clients_.begin(), clients_.end(), remoteAddr_) == clients_.end())
-    //{
-    //  clients_.push_back(remoteAddr_);
-    //}
-    clients_[remoteAddr_] = macToReg;
-  }
+			sendPacket(outData, eMessageType::DSUS_PortInfo, 1001);
+		}
+	}
+	else if (messageType == eMessageType::DSUC_PadDataReq)
+	{
+		uint8_t regFlags = *(uint8_t*)(buffer_ + currIdx);
+		currIdx += 1;
+		uint8_t idToReg = *(uint8_t*)(buffer_ + currIdx);
+		currIdx += 1;
+		PhysicalAddress macToReg = *(PhysicalAddress*)(buffer_ + currIdx);
+		currIdx += 6;
+
+		//if (std::find(clients_.begin(), clients_.end(), remoteAddr_) == clients_.end())
+		//{
+		//  clients_.push_back(remoteAddr_);
+		//}
+		clients_[remoteAddr_] = macToReg;
+	}
 }
 
 int UdpServer::beginPacket(std::vector<char>& packetData, UdpServer::eMessageType messageType, uint16_t reqProtocolVersion)
 {
-  PacketHeader* packetHeader = (PacketHeader*)(packetData.data());
-  packetHeader->Header[0] = 'D';
-  packetHeader->Header[1] = 'S';
-  packetHeader->Header[2] = 'U';
-  packetHeader->Header[3] = 'S';
-  packetHeader->Version = reqProtocolVersion;
-  packetHeader->Length = (uint16_t)(packetData.size() - 16);
-  packetHeader->Crc32 = 0;
-  packetHeader->ServerId = serverId_;
-  packetHeader->MessageType = (uint32_t)messageType;
+	PacketHeader* packetHeader = (PacketHeader*)(packetData.data());
+	packetHeader->Header[0] = 'D';
+	packetHeader->Header[1] = 'S';
+	packetHeader->Header[2] = 'U';
+	packetHeader->Header[3] = 'S';
+	packetHeader->Version = reqProtocolVersion;
+	packetHeader->Length = (uint16_t)(packetData.size() - 16);
+	packetHeader->Crc32 = 0;
+	packetHeader->ServerId = serverId_;
+	packetHeader->MessageType = (uint32_t)messageType;
 
-  return sizeof(PacketHeader);
+	return sizeof(PacketHeader);
 }
 
 void UdpServer::finishPacket(std::vector<char>& packetData)
 {
-  uint32_t crc32 = CRC::Calculate(packetData.data(), packetData.size(), CRC::CRC_32());
-  PacketHeader* packetHeader = (PacketHeader*)(packetData.data());
-  packetHeader->Crc32 = crc32;
+	uint32_t crc32 = CRC::Calculate(packetData.data(), packetData.size(), CRC::CRC_32());
+	PacketHeader* packetHeader = (PacketHeader*)(packetData.data());
+	packetHeader->Crc32 = crc32;
 }
 
 void UdpServer::sendPacket(std::vector<char>& buffer, UdpServer::eMessageType messageType, uint16_t reqProtocolVersion)
 {
-  packetData_.resize(buffer.size() + sizeof(PacketHeader));
-  memset(packetData_.data(), 0, buffer.size() + sizeof(PacketHeader));
-  int curIdx = beginPacket(packetData_, messageType, reqProtocolVersion);
-  memcpy(packetData_.data() + curIdx, buffer.data(), buffer.size());
-  finishPacket(packetData_);
+	packetData_.resize(buffer.size() + sizeof(PacketHeader));
+	memset(packetData_.data(), 0, buffer.size() + sizeof(PacketHeader));
+	int curIdx = beginPacket(packetData_, messageType, reqProtocolVersion);
+	memcpy(packetData_.data() + curIdx, buffer.data(), buffer.size());
+	finishPacket(packetData_);
 
-  if (sendto(socket_, packetData_.data(), (uint32_t)packetData_.size(), 0, (SOCKADDR*)&remoteAddr_, sizeof(SOCKADDR_IN)) == SOCKET_ERROR)
-  {
-    throw std::runtime_error("Something went wrong");
-  }
+	if (sendto(socket_, packetData_.data(), (uint32_t)packetData_.size(), 0, (SOCKADDR*)&remoteAddr_, sizeof(SOCKADDR_IN)) == SOCKET_ERROR)
+	{
+		throw std::runtime_error("Something went wrong");
+	}
 }

--- a/UdpServer.h
+++ b/UdpServer.h
@@ -1,0 +1,181 @@
+#pragma once
+
+#include <vector>
+#include <unordered_map>
+
+#define _WINSOCKAPI_
+#include <WinSock2.h>
+
+#include "Controller.hpp"
+
+enum class DsState : uint8_t
+{
+  DISCONNECTED = 0x00,
+  RESERVED = 0x01,
+  CONNECTED = 0x02
+};
+
+enum class DsConnection : uint8_t
+{
+  NONE = 0x00,
+  USB = 0x01,
+  BLUETOOTH = 0x02
+};
+
+enum class DsModel : uint8_t
+{
+  NONE = 0x00,
+  DS3 = 0x01,
+  DS4 = 0x02,
+  GENERIC = 0x03
+};
+
+enum class DsBattery : uint8_t
+{
+  NONE = 0x00,
+  DYING = 0x01,
+  LOW = 0x02,
+  MEDIUM = 0x03,
+  HIGH = 0x04,
+  FULL = 0x05,
+  CHARGING = 0xEE,
+  CHARGED = 0xEF
+};
+
+#pragma pack(push, 1)
+struct PhysicalAddress
+{
+  uint16_t byte1;
+  uint16_t byte2;
+  uint16_t byte3;
+};
+
+struct GamePadMeta
+{
+  uint8_t PadId;
+  DsState PadState;
+  DsModel Model;
+  DsConnection ConnectionType;
+  PhysicalAddress PadMacAddress;
+  DsBattery BatteryStatus;
+  uint8_t IsActive;
+};
+
+struct TouchPad
+{
+  uint8_t IsActive;
+  uint8_t Id;
+  uint16_t X;
+  uint16_t Y;
+};
+
+struct PacketHeader
+{
+  char Header[4];
+  uint16_t Version;
+  uint16_t Length;
+  uint32_t Crc32;
+  uint32_t ServerId;
+  uint32_t MessageType;
+};
+
+struct ProtocolPacket
+{
+  PacketHeader HeaderData;
+  GamePadMeta Metadata;
+  uint32_t PacketCounter;
+  uint8_t LeftKeys;
+  uint8_t RightKeys;
+  uint8_t PS;
+  uint8_t TouchButton;
+  uint16_t LeftStick;
+  uint16_t RightStick;
+  uint8_t DpadLeft;
+  uint8_t DpadDown;
+  uint8_t DpadRight;
+  uint8_t DpadUp;
+  uint8_t KeyY;
+  uint8_t KeyB;
+  uint8_t KeyA;
+  uint8_t KeyX;
+  uint8_t KeyR;
+  uint8_t KeyL;
+  uint8_t KeyZR;
+  uint8_t KeyZL;
+  TouchPad TPad0;
+  TouchPad TPad1;
+  uint64_t MotionTimestamp;
+  uint32_t AccelX;
+  uint32_t AccelY;
+  uint32_t AccelZ;
+  uint32_t GyroPitch;
+  uint32_t GyroYaw;
+  uint32_t GyroRoll;
+};
+#pragma pack(pop)
+
+struct SOCKADDR_IN_HASH
+{
+  std::size_t operator()(const SOCKADDR_IN& a) const
+  {
+    return (std::hash<uint32_t>()(a.sin_addr.S_un.S_addr)
+         ^ (std::hash<uint16_t>()(a.sin_port))
+         ^ (std::hash<uint16_t>()(a.sin_family)));
+  }
+};
+
+struct SOCKADDR_IN_EQUAL
+{
+  bool operator()(const SOCKADDR_IN& a1, const SOCKADDR_IN& a2) const
+  {
+    return a1.sin_family == a2.sin_family
+      && a1.sin_port == a2.sin_port
+      && a1.sin_addr.S_un.S_addr == a2.sin_addr.S_un.S_addr;
+  }
+};
+
+class UdpServer
+{
+public:
+  UdpServer();
+
+  void receive();
+  void newReportIncoming(const Procon::ExpandedPadState& state);
+
+private:
+  enum class eMessageType : uint32_t
+  {
+    DSUC_VersionReq = 0x100000,
+    DSUS_VersionRsp = 0x100000,
+    DSUC_ListPorts = 0x100001,
+    DSUS_PortInfo = 0x100001,
+    DSUC_PadDataReq = 0x100002,
+    DSUS_PadDataRsp = 0x100002,
+  };
+
+  static const constexpr uint16_t MaxProtocolVersion = 1001;
+  static const constexpr uint16_t BufferLength = 512;
+
+  void processIncoming(int recv_len);
+
+  int beginPacket(std::vector<char>& packetData, eMessageType messageType, uint16_t reqProtocolVersion);
+  void sendPacket(std::vector<char>& buffer, eMessageType messageType, uint16_t reqProtocolVersion = MaxProtocolVersion);
+  void finishPacket(std::vector<char>& packetData);
+
+  // Temporary
+  GamePadMeta gamePad_;
+  GamePadMeta gamePadNone_;
+  uint32_t packetCounter_;
+  // Temporary
+
+  SOCKET socket_;
+  SOCKADDR_IN addr_;
+  SOCKADDR_IN remoteAddr_;
+
+  std::unordered_map<SOCKADDR_IN, PhysicalAddress, SOCKADDR_IN_HASH, SOCKADDR_IN_EQUAL> clients_;
+
+  uint32_t serverId_;
+
+  char buffer_[BufferLength];
+  std::vector<char> packetData_;
+};

--- a/UdpServer.h
+++ b/UdpServer.h
@@ -10,172 +10,172 @@
 
 enum class DsState : uint8_t
 {
-  DISCONNECTED = 0x00,
-  RESERVED = 0x01,
-  CONNECTED = 0x02
+	DISCONNECTED = 0x00,
+	RESERVED = 0x01,
+	CONNECTED = 0x02
 };
 
 enum class DsConnection : uint8_t
 {
-  NONE = 0x00,
-  USB = 0x01,
-  BLUETOOTH = 0x02
+	NONE = 0x00,
+	USB = 0x01,
+	BLUETOOTH = 0x02
 };
 
 enum class DsModel : uint8_t
 {
-  NONE = 0x00,
-  DS3 = 0x01,
-  DS4 = 0x02,
-  GENERIC = 0x03
+	NONE = 0x00,
+	DS3 = 0x01,
+	DS4 = 0x02,
+	GENERIC = 0x03
 };
 
 enum class DsBattery : uint8_t
 {
-  NONE = 0x00,
-  DYING = 0x01,
-  LOW = 0x02,
-  MEDIUM = 0x03,
-  HIGH = 0x04,
-  FULL = 0x05,
-  CHARGING = 0xEE,
-  CHARGED = 0xEF
+	NONE = 0x00,
+	DYING = 0x01,
+	LOW = 0x02,
+	MEDIUM = 0x03,
+	HIGH = 0x04,
+	FULL = 0x05,
+	CHARGING = 0xEE,
+	CHARGED = 0xEF
 };
 
 #pragma pack(push, 1)
 struct PhysicalAddress
 {
-  uint16_t byte1;
-  uint16_t byte2;
-  uint16_t byte3;
+	uint16_t byte1;
+	uint16_t byte2;
+	uint16_t byte3;
 };
 
 struct GamePadMeta
 {
-  uint8_t PadId;
-  DsState PadState;
-  DsModel Model;
-  DsConnection ConnectionType;
-  PhysicalAddress PadMacAddress;
-  DsBattery BatteryStatus;
-  uint8_t IsActive;
+	uint8_t PadId;
+	DsState PadState;
+	DsModel Model;
+	DsConnection ConnectionType;
+	PhysicalAddress PadMacAddress;
+	DsBattery BatteryStatus;
+	uint8_t IsActive;
 };
 
 struct TouchPad
 {
-  uint8_t IsActive;
-  uint8_t Id;
-  uint16_t X;
-  uint16_t Y;
+	uint8_t IsActive;
+	uint8_t Id;
+	uint16_t X;
+	uint16_t Y;
 };
 
 struct PacketHeader
 {
-  char Header[4];
-  uint16_t Version;
-  uint16_t Length;
-  uint32_t Crc32;
-  uint32_t ServerId;
-  uint32_t MessageType;
+	char Header[4];
+	uint16_t Version;
+	uint16_t Length;
+	uint32_t Crc32;
+	uint32_t ServerId;
+	uint32_t MessageType;
 };
 
 struct ProtocolPacket
 {
-  PacketHeader HeaderData;
-  GamePadMeta Metadata;
-  uint32_t PacketCounter;
-  uint8_t LeftKeys;
-  uint8_t RightKeys;
-  uint8_t PS;
-  uint8_t TouchButton;
-  uint16_t LeftStick;
-  uint16_t RightStick;
-  uint8_t DpadLeft;
-  uint8_t DpadDown;
-  uint8_t DpadRight;
-  uint8_t DpadUp;
-  uint8_t KeyY;
-  uint8_t KeyB;
-  uint8_t KeyA;
-  uint8_t KeyX;
-  uint8_t KeyR;
-  uint8_t KeyL;
-  uint8_t KeyZR;
-  uint8_t KeyZL;
-  TouchPad TPad0;
-  TouchPad TPad1;
-  uint64_t MotionTimestamp;
-  uint32_t AccelX;
-  uint32_t AccelY;
-  uint32_t AccelZ;
-  uint32_t GyroPitch;
-  uint32_t GyroYaw;
-  uint32_t GyroRoll;
+	PacketHeader HeaderData;
+	GamePadMeta Metadata;
+	uint32_t PacketCounter;
+	uint8_t LeftKeys;
+	uint8_t RightKeys;
+	uint8_t PS;
+	uint8_t TouchButton;
+	uint16_t LeftStick;
+	uint16_t RightStick;
+	uint8_t DpadLeft;
+	uint8_t DpadDown;
+	uint8_t DpadRight;
+	uint8_t DpadUp;
+	uint8_t KeyY;
+	uint8_t KeyB;
+	uint8_t KeyA;
+	uint8_t KeyX;
+	uint8_t KeyR;
+	uint8_t KeyL;
+	uint8_t KeyZR;
+	uint8_t KeyZL;
+	TouchPad TPad0;
+	TouchPad TPad1;
+	uint64_t MotionTimestamp;
+	uint32_t AccelX;
+	uint32_t AccelY;
+	uint32_t AccelZ;
+	uint32_t GyroPitch;
+	uint32_t GyroYaw;
+	uint32_t GyroRoll;
 };
 #pragma pack(pop)
 
 struct SOCKADDR_IN_HASH
 {
-  std::size_t operator()(const SOCKADDR_IN& a) const
-  {
-    return (std::hash<uint32_t>()(a.sin_addr.S_un.S_addr)
-         ^ (std::hash<uint16_t>()(a.sin_port))
-         ^ (std::hash<uint16_t>()(a.sin_family)));
-  }
+	std::size_t operator()(const SOCKADDR_IN& a) const
+	{
+		return (std::hash<uint32_t>()(a.sin_addr.S_un.S_addr)
+			^ (std::hash<uint16_t>()(a.sin_port))
+			^ (std::hash<uint16_t>()(a.sin_family)));
+	}
 };
 
 struct SOCKADDR_IN_EQUAL
 {
-  bool operator()(const SOCKADDR_IN& a1, const SOCKADDR_IN& a2) const
-  {
-    return a1.sin_family == a2.sin_family
-      && a1.sin_port == a2.sin_port
-      && a1.sin_addr.S_un.S_addr == a2.sin_addr.S_un.S_addr;
-  }
+	bool operator()(const SOCKADDR_IN& a1, const SOCKADDR_IN& a2) const
+	{
+		return a1.sin_family == a2.sin_family
+			&& a1.sin_port == a2.sin_port
+			&& a1.sin_addr.S_un.S_addr == a2.sin_addr.S_un.S_addr;
+	}
 };
 
 class UdpServer
 {
 public:
-  UdpServer();
+	UdpServer();
 
-  void receive();
-  void newReportIncoming(const Procon::ExpandedPadState& state);
+	void receive();
+	void newReportIncoming(const Procon::ExpandedPadState& state);
 
 private:
-  enum class eMessageType : uint32_t
-  {
-    DSUC_VersionReq = 0x100000,
-    DSUS_VersionRsp = 0x100000,
-    DSUC_ListPorts = 0x100001,
-    DSUS_PortInfo = 0x100001,
-    DSUC_PadDataReq = 0x100002,
-    DSUS_PadDataRsp = 0x100002,
-  };
+	enum class eMessageType : uint32_t
+	{
+		DSUC_VersionReq = 0x100000,
+		DSUS_VersionRsp = 0x100000,
+		DSUC_ListPorts = 0x100001,
+		DSUS_PortInfo = 0x100001,
+		DSUC_PadDataReq = 0x100002,
+		DSUS_PadDataRsp = 0x100002,
+	};
 
-  static const constexpr uint16_t MaxProtocolVersion = 1001;
-  static const constexpr uint16_t BufferLength = 512;
+	static const constexpr uint16_t MaxProtocolVersion = 1001;
+	static const constexpr uint16_t BufferLength = 512;
 
-  void processIncoming(int recv_len);
+	void processIncoming(int recv_len);
 
-  int beginPacket(std::vector<char>& packetData, eMessageType messageType, uint16_t reqProtocolVersion);
-  void sendPacket(std::vector<char>& buffer, eMessageType messageType, uint16_t reqProtocolVersion = MaxProtocolVersion);
-  void finishPacket(std::vector<char>& packetData);
+	int beginPacket(std::vector<char>& packetData, eMessageType messageType, uint16_t reqProtocolVersion);
+	void sendPacket(std::vector<char>& buffer, eMessageType messageType, uint16_t reqProtocolVersion = MaxProtocolVersion);
+	void finishPacket(std::vector<char>& packetData);
 
-  // Temporary
-  GamePadMeta gamePad_;
-  GamePadMeta gamePadNone_;
-  uint32_t packetCounter_;
-  // Temporary
+	// Temporary
+	GamePadMeta gamePad_;
+	GamePadMeta gamePadNone_;
+	uint32_t packetCounter_;
+	// Temporary
 
-  SOCKET socket_;
-  SOCKADDR_IN addr_;
-  SOCKADDR_IN remoteAddr_;
+	SOCKET socket_;
+	SOCKADDR_IN addr_;
+	SOCKADDR_IN remoteAddr_;
 
-  std::unordered_map<SOCKADDR_IN, PhysicalAddress, SOCKADDR_IN_HASH, SOCKADDR_IN_EQUAL> clients_;
+	std::unordered_map<SOCKADDR_IN, PhysicalAddress, SOCKADDR_IN_HASH, SOCKADDR_IN_EQUAL> clients_;
 
-  uint32_t serverId_;
+	uint32_t serverId_;
 
-  char buffer_[BufferLength];
-  std::vector<char> packetData_;
+	char buffer_[BufferLength];
+	std::vector<char> packetData_;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,7 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+#define _WINSOCKAPI_
 #include <Windows.h>
 #include <conio.h> // _kbhit, _getch_nolock
 #include "XOutput.hpp"
@@ -16,6 +17,7 @@
 #include "Cerberus.hpp"
 #include "Version.hpp"
 #include "Config.hpp"
+#include "UdpServer.h"
 
 namespace {
 	bool hasBroke{ false };
@@ -132,6 +134,8 @@ int main(int, char*[]) {
 	cout << "Press CTRL+C to exit.\n\n";
 	::setBreakHandler();
 
+  UdpServer udpServer;
+
 	std::array<bool, 4> hasCentered;
 	hasCentered.fill(false);
 
@@ -142,7 +146,9 @@ int main(int, char*[]) {
 			for (size_t i = 0; i < port; ++i) {
 				cs[i].pollInput();
         const Procon::ExpandedPadState &state = cs[i].getState();
+        udpServer.newReportIncoming(state);
 			}
+      udpServer.receive();
 			yield(); // sleep_for causes big lag and not yielding eats way more processor
 		}
 	}

--- a/main.cpp
+++ b/main.cpp
@@ -129,12 +129,6 @@ int main(int, char*[]) {
 	}
 
 	cout << "\nConnected to " << static_cast<int>(port) << " controller(s). Beginning xInput emulation.\n\n";
-	
-	cout << "Doing calibration, stick min/maxes will be updated automatically.\n";
-	cout << "Move the sticks some, then let them reset to neutral.\n";
-	cout << "Press the Share button to set stick center. This only works once per controller currently!\n";
-	cout << "XInput may be laggier before stick center for all controllers is set!\n\n";
-	
 	cout << "Press CTRL+C to exit.\n\n";
 	::setBreakHandler();
 
@@ -144,26 +138,10 @@ int main(int, char*[]) {
 	try {
 		// Testing to set centers, additional comparisons = slower so make it a separate loop
 		size_t countCentered{ 0 };
-		while (!::hasBroke && countCentered < port) {
-			for (size_t i = 0; i < port; ++i) {
-				cs[i].pollInput();
-				if (!hasCentered[i]) {
-					const Procon::ExpandedPadState &state = cs[i].getState();
-					if (state.sharePressed) {
-						cs[i].setCalibrationCenter(state.leftStick, state.rightStick);
-						hasCentered[i] = true;
-						++countCentered;
-						cout << "Set stick centers for controller LED " << i + 1 << '\n';
-					}
-				}
-			}
-			yield();
-		}
-		cout << "\nAll controller stick centers set, entering fast input loop. Enjoy your games!\n";
-		// Centers set, main input loop
 		while(!::hasBroke){
 			for (size_t i = 0; i < port; ++i) {
 				cs[i].pollInput();
+        const Procon::ExpandedPadState &state = cs[i].getState();
 			}
 			yield(); // sleep_for causes big lag and not yielding eats way more processor
 		}

--- a/main.cpp
+++ b/main.cpp
@@ -100,7 +100,7 @@ int main(int, char*[]) {
 		cout << "Continuing, may not find the controller if it's hidden by HidGuardian.\n";
 	}
 #endif
-	
+
 	std::vector<Controller> cs;
 	uchar port{ 0 };
 	{
@@ -134,7 +134,7 @@ int main(int, char*[]) {
 	cout << "Press CTRL+C to exit.\n\n";
 	::setBreakHandler();
 
-  UdpServer udpServer;
+	UdpServer udpServer;
 
 	std::array<bool, 4> hasCentered;
 	hasCentered.fill(false);
@@ -142,13 +142,13 @@ int main(int, char*[]) {
 	try {
 		// Testing to set centers, additional comparisons = slower so make it a separate loop
 		size_t countCentered{ 0 };
-		while(!::hasBroke){
+		while (!::hasBroke) {
 			for (size_t i = 0; i < port; ++i) {
 				cs[i].pollInput();
-        const Procon::ExpandedPadState &state = cs[i].getState();
-        udpServer.newReportIncoming(state);
+				const Procon::ExpandedPadState &state = cs[i].getState();
+				udpServer.newReportIncoming(state);
 			}
-      udpServer.receive();
+			udpServer.receive();
 			yield(); // sleep_for causes big lag and not yielding eats way more processor
 		}
 	}


### PR DESCRIPTION
Hey MTCKC,

I made a woking implementation to:

 - read spi calibration values and use them
 - read motion sensordata from controller
 - publish motion data via udp server using the format that DS4Windows uses

with this changes I am able to use motion data with cemu.

I also changed the eventloop to use the `pushed` notifications of controller changes instead of polling with a `hid command`. Sometimes when I start the application there are no motion sensor data available. Most of the time I am able to restart the application and I get the sensor data. I do not know why this happens currently.

I restructured the `Controller.cpp` a bit in this process (I hope this will not be any problem).
I also updated the windows sdk and added a sln file.

The server is not completly correcly implemented. If a client disconnects we do not account for it and still sends data to him. I think this is also the problem why the application leaks a bit of memory. After ca 2h of usage the applications memory grow from ~20MB to ~40MB. This should be corrected with another PR. I think this also leads to the higher cpu usage after time passes.

Have a nice holiday.

Greetings nagua